### PR TITLE
generate_objects: use rewind=True in upload_objects

### DIFF
--- a/s3tests/generate_objects.py
+++ b/s3tests/generate_objects.py
@@ -46,7 +46,7 @@ def upload_objects(bucket, files, seed):
         print >> sys.stderr, 'sending file with size %dB' % fp.size
         key = Key(bucket)
         key.key = name_generator.next()
-        key.set_contents_from_file(fp)
+        key.set_contents_from_file(fp, rewind=True)
         key.set_acl('public-read')
         keys.append(key)
 


### PR DESCRIPTION
Use the rewind=True argument when uploading objects to make
realistic.py's use of upload_objects compatible with boto>=2.4.1, which
will try to seek to the end of the fp if rewind is not True.
