### PR TITLE
Fixed error in test_bucket_create_bad_contentlength_empty test

### DIFF
--- a/s3tests/functional/test_headers.py
+++ b/s3tests/functional/test_headers.py
@@ -716,9 +716,8 @@ def _create_new_connection():
 @nose.with_setup(teardown=_clear_custom_headers)
 @attr('fails_on_rgw')
 def test_bucket_create_bad_contentlength_empty():
-    conn = _create_new_connection()
     _add_custom_headers({'Content-Length': ''})
-    e = assert_raises(boto.exception.S3ResponseError, get_new_bucket, conn)
+    e = assert_raises(boto.exception.S3ResponseError, get_new_bucket)
 
     eq(e.status, 400)
     eq(e.reason, 'Bad Request')


### PR DESCRIPTION
Seems like test_bucket_create_bad_contentlength_empty test has been broken by latest commits. This pull request fixes it.

linuxmint@linuxmint-virtual-machine ~/s3-tests $ S3TEST_CONF=user.conf ./virtualenv/bin/nosetests --verbosity=3 --detailed-errors s3tests.functional.test_headers:test_bucket_create_bad_contentlength_empty
nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
s3tests.functional.test_headers.test_bucket_create_bad_contentlength_empty ... ERROR

ERROR: s3tests.functional.test_headers.test_bucket_create_bad_contentlength_empty

Traceback (most recent call last):
  File "/home/linuxmint/s3-tests/virtualenv/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/linuxmint/s3-tests/s3tests/functional/test_headers.py", line 721, in test_bucket_create_bad_contentlength_empty
    e = assert_raises(boto.exception.S3ResponseError, get_new_bucket, conn)
  File "/home/linuxmint/s3-tests/s3tests/functional/utils.py", line 6, in assert_raises
    callableObj(*args, **kwargs)
  File "/home/linuxmint/s3-tests/s3tests/functional/__init__.py", line 317, in get_new_bucket
    bucket = connection.create_bucket(name, location=target.conf.api_name, headers=headers)
AttributeError: HTTPSConnection instance has no attribute 'create_bucket'
-------------------- >> begin captured logging << --------------------
boto: DEBUG: Using access key provided by client.
boto: DEBUG: Using secret key provided by client.
boto: DEBUG: Using access key provided by client.
boto: DEBUG: Using secret key provided by client.
boto: DEBUG: path=/
boto: DEBUG: auth_path=/
boto: DEBUG: Method: GET
boto: DEBUG: Path: /
boto: DEBUG: Data:
boto: DEBUG: Headers: {}
boto: DEBUG: Host: s3.amazonaws.com
boto: DEBUG: Params: {}
boto: DEBUG: establishing HTTPS connection: host=s3.amazonaws.com, kwargs={'timeout': 70}
boto: DEBUG: Token: None
boto: DEBUG: StringToSign:
GET


Tue, 20 Aug 2013 11:04:06 GMT
/
boto: DEBUG: Signature:
AWS AKIAJBJ442UX4NFYX4IA:BFi2gxKfLt6JmG0p/N65MBPfuzg=
boto: DEBUG: path=/
boto: DEBUG: auth_path=/
boto: DEBUG: Method: GET
boto: DEBUG: Path: /
boto: DEBUG: Data:
boto: DEBUG: Headers: {}
boto: DEBUG: Host: s3.amazonaws.com
boto: DEBUG: Params: {}
boto: DEBUG: establishing HTTPS connection: host=s3.amazonaws.com, kwargs={'timeout': 70}
boto: DEBUG: Token: None
boto: DEBUG: StringToSign:
GET


Tue, 20 Aug 2013 11:04:08 GMT
/
boto: DEBUG: Signature:
AWS AKIAJTQF5ZGMZGR7JOKA:ySOQhprurgDnxlKLztn21w604B4=
boto: DEBUG: Using access key provided by client.
boto: DEBUG: Using secret key provided by client.
boto: DEBUG: establishing HTTPS connection: host=s3.amazonaws.com, kwargs={'timeout': 70}
--------------------- >> end captured logging << ---------------------

Ran 1 test in 5.835s

FAILED (errors=1) 