### PR TITLE
Remove test_bucket_recreate_not_overriding

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -5996,23 +5996,6 @@ def test_bucket_create_naming_good_contains_period():
 def test_bucket_create_naming_good_contains_hyphen():
     check_good_bucket_name('aaa-111')
 
-@attr(resource='bucket')
-@attr(method='put')
-@attr(operation='create bucket with objects and recreate it')
-@attr(assertion='bucket recreation not overriding index')
-def test_bucket_recreate_not_overriding():
-    key_names = ['mykey1', 'mykey2']
-    bucket_name = _create_objects(keys=key_names)
-
-    objs_list = get_objects_list(bucket_name)
-    eq(key_names, objs_list)
-
-    client = get_client()
-    client.create_bucket(Bucket=bucket_name)
-
-    objs_list = get_objects_list(bucket_name)
-    eq(key_names, objs_list)
-
 @attr(resource='object')
 @attr(method='put')
 @attr(operation='create and list objects with special names')


### PR DESCRIPTION
This test fails on AWS in regions other than us-standard.  See #9 for
more discussion.
