### PR TITLE
Disable retries to test short writes

### DIFF
--- a/s3tests/functional/test_headers.py
+++ b/s3tests/functional/test_headers.py
@@ -340,6 +340,11 @@ def test_object_create_bad_contentlength_mismatch_above():
 
     key = _setup_bad_object({'Content-Length': length})
 
+    # Disable retries since key.should_retry will discard the response with
+    # PleaseRetryException.
+    def no_retry(response, chunked_transfer): return False
+    key.should_retry = no_retry
+
     e = assert_raises(boto.exception.S3ResponseError, key.set_contents_from_string, content)
     eq(e.status, 400)
     eq(e.reason, 'Bad Request')


### PR DESCRIPTION
Previously test_object_create_bad_contentlength_mismatch_above failed
with:

```
Traceback (most recent call last):
  File "/home/gaul/work/s3-tests/virtualenv/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/gaul/work/s3-tests/s3tests/functional/test_headers.py", line 343, in test_object_create_bad_contentlength_mismatch_above
    e = assert_raises(boto.exception.S3ResponseError, key.set_contents_from_string, content)
  File "/home/gaul/work/s3-tests/s3tests/functional/utils.py", line 11, in assert_raises
    callableObj(*args, **kwargs)
  File "/home/gaul/work/s3-tests/virtualenv/local/lib/python2.7/site-packages/boto/s3/key.py", line 1379, in set_contents_from_string
    encrypt_key=encrypt_key)
  File "/home/gaul/work/s3-tests/virtualenv/local/lib/python2.7/site-packages/boto/s3/key.py", line 1246, in set_contents_from_file
    chunked_transfer=chunked_transfer, size=size)
  File "/home/gaul/work/s3-tests/virtualenv/local/lib/python2.7/site-packages/boto/s3/key.py", line 725, in send_file
    chunked_transfer=chunked_transfer, size=size)
  File "/home/gaul/work/s3-tests/virtualenv/local/lib/python2.7/site-packages/boto/s3/key.py", line 914, in _send_file_internal
    query_args=query_args
  File "/home/gaul/work/s3-tests/virtualenv/local/lib/python2.7/site-packages/boto/s3/connection.py", line 658, in make_request
    retry_handler=retry_handler
  File "/home/gaul/work/s3-tests/virtualenv/local/lib/python2.7/site-packages/boto/connection.py", line 1048, in make_request
    retry_handler=retry_handler)
  File "/home/gaul/work/s3-tests/virtualenv/local/lib/python2.7/site-packages/boto/connection.py", line 1004, in _mexe
    raise BotoServerError(response.status, response.reason, body)
BotoServerError: BotoServerError: 400 Bad Request
```