### PR TITLE
Handle idempotent and BucketAlreadyOwnedByYou

### DIFF
--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -2628,11 +2628,16 @@ def test_bucket_create_naming_dns_dash_dot():
 @attr(resource='bucket')
 @attr(method='put')
 @attr(operation='re-create')
-@attr(assertion='idempotent success')
 def test_bucket_create_exists():
+    # aws-s3 default region allows recreation of buckets
+    # but all other regions fail with BucketAlreadyOwnedByYou.
     bucket = get_new_bucket(targets.main.default)
-    # REST idempotency means this should be a nop
-    get_new_bucket(targets.main.default, bucket.name)
+    try:
+        get_new_bucket(targets.main.default, bucket.name)
+    except boto.exception.S3CreateError, e:
+        eq(e.status, 409)
+        eq(e.reason, 'Conflict')
+        eq(e.error_code, 'BucketAlreadyOwnedByYou')
 
 
 @attr(resource='bucket')


### PR DESCRIPTION
AWS S3 has two behaviors for recreating a bucket depending if you use
the us-standard or another region:

```
>>> bucket = conn.create_bucket('gaul-default', location=Location.DEFAULT)
>>> bucket = conn.create_bucket('gaul-default', location=Location.DEFAULT)
>>> bucket = conn.create_bucket('gaul-uswest', location=Location.USWest)
>>> bucket = conn.create_bucket('gaul-uswest', location=Location.USWest)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/dist-packages/boto/s3/connection.py", line 499, in create_bucket
    response.status, response.reason, body)
boto.exception.S3CreateError: S3CreateError: 409 Conflict
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>BucketAlreadyOwnedByYou</Code><Message>Your previous request to create the named bucket succeeded and you already own it.</Message><BucketName>gaul-uswest</BucketName><RequestId>24B6DC3170365CD7</RequestId><HostId>hUynMTyqc9WZFxAJ2RFK6P7BqmmeHHlMl9xL2NOy56xBUnOZCAlHqGvtMeGeAfVs</HostId></Error>
```

Additional discussion:

https://issues.apache.org/jira/browse/JCLOUDS-334