### PR TITLE
Do not check error_code with empty content length

### DIFF
--- a/s3tests/functional/test_headers.py
+++ b/s3tests/functional/test_headers.py
@@ -722,7 +722,6 @@ def test_bucket_create_bad_contentlength_empty():
 
     eq(e.status, 400)
     eq(e.reason, 'Bad Request')
-    eq(e.error_code, None)
 
 
 @attr(resource='bucket')


### PR DESCRIPTION
This matches test_bucket_create_bad_contentlength_negative.