### PR TITLE
disable 2 tests that currently fail in DHO

### DIFF
--- a/s3tests/functional/test_headers.py
+++ b/s3tests/functional/test_headers.py
@@ -337,6 +337,7 @@ def test_object_create_bad_contentlength_unreadable():
 @attr(assertion='fails 400')
 @nose.with_setup(teardown=_clear_custom_headers)
 @attr('fails_on_rgw')
+@attr('fails_on_dho')
 def test_object_create_bad_contentlength_mismatch_above():
     content = 'bar'
     length = len(content) + 1

--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -4412,6 +4412,7 @@ def _cors_request_and_check(func, url, headers, expect_status, expect_allow_orig
 @attr(method='get')
 @attr(operation='check cors response when origin header set')
 @attr(assertion='returning cors header')
+@attr('fails_on_dho')
 def test_cors_origin_response():
     cfg = CORSConfiguration()
     bucket = get_new_bucket()


### PR DESCRIPTION
Disable these 2 tests that are currently failing in DHO:
s3tests.functional.test_headers.test_object_create_bad_contentlength_mismatch_above
s3tests.functional.test_s3.test_cors_origin_response