### PR TITLE
Add fails_on_mod_proxy_fcgi to functional.test_s3.test_100_continue

### DIFF
--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -4673,6 +4673,7 @@ def _simple_http_req_100_cont(host, port, is_secure, method, resource):
 @attr(operation='w/expect continue')
 @attr(assertion='succeeds if object is public-read-write')
 @attr('100_continue')
+@attr('fails_on_mod_proxy_fcgi')
 def test_100_continue():
     bucket = get_new_bucket()
     objname = 'testobj'


### PR DESCRIPTION
mod_proxy_fcgi only has partial 100 continue support so we want to skip this test when testing against it.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>