### PR TITLE
Replace and retain Content-Type in copy tests

### DIFF
--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -4441,14 +4441,18 @@ def test_object_copy_canned_acl():
 def test_object_copy_retaining_metadata():
     bucket = get_new_bucket()
     key = bucket.new_key('foo123bar')
-    key.set_contents_from_string('foo')
     metadata = {'key1': 'value1', 'key2': 'value2'}
-    key.set_remote_metadata(metadata, {}, False)
+    key.set_metadata('key1', 'value1')
+    key.set_metadata('key2', 'value2')
+    content_type = 'audio/ogg'
+    key.content_type = content_type
+    key.set_contents_from_string('foo')
 
     bucket.copy_key('bar321foo', bucket.name, 'foo123bar')
     key2 = bucket.get_key('bar321foo')
     eq(key2.size, 3)
     eq(key2.metadata, metadata)
+    eq(key2.content_type, content_type)
 
 @attr(resource='object')
 @attr(method='put')
@@ -4456,14 +4460,18 @@ def test_object_copy_retaining_metadata():
 def test_object_copy_replacing_metadata():
     bucket = get_new_bucket()
     key = bucket.new_key('foo123bar')
+    key.set_metadata('key1', 'value1')
+    key.set_metadata('key2', 'value2')
+    key.content_type = 'audio/ogg'
     key.set_contents_from_string('foo')
-    key.set_remote_metadata({'key1': 'value1', 'key2': 'value2'}, {}, False)
 
     metadata = {'key3': 'value3', 'key1': 'value4'}
-    bucket.copy_key('bar321foo', bucket.name, 'foo123bar', metadata=metadata)
+    content_type = 'audio/mpeg'
+    bucket.copy_key('bar321foo', bucket.name, 'foo123bar', metadata=metadata, headers={'Content-Type': content_type})
     key2 = bucket.get_key('bar321foo')
     eq(key2.size, 3)
     eq(key2.metadata, metadata)
+    eq(key2.content_type, content_type)
 
 def transfer_part(bucket, mp_id, mp_keyname, i, part):
     """Transfer a part of a multipart upload. Designed to be run in parallel.


### PR DESCRIPTION
Also set user metadata during put instead of issuing an additional
copy.