### PR TITLE
Fall back when nuking buckets

### DIFF
--- a/s3tests/functional/__init__.py
+++ b/s3tests/functional/__init__.py
@@ -67,7 +67,17 @@ def nuke_prefixed_buckets_on_conn(prefix, name, conn):
             success = False
             for i in xrange(2):
                 try:
-                    for key in bucket.list_versions():
+                    try:
+                        iterator = iter(bucket.list_versions())
+                        # peek into iterator to issue list operation
+                        keys = itertools.chain([next(iterator)], iterator)
+                    except boto.exception.S3ResponseError as e:
+                        # some S3 implementations do not support object
+                        # versioning - fall back to listing without versions
+                        if e.error_code != 'NotImplemented':
+                            raise e
+                        keys = bucket.list();
+                    for key in keys:
                         print 'Cleaning bucket {bucket} key {key}'.format(
                             bucket=bucket,
                             key=key,


### PR DESCRIPTION
Some S3 implementations do not support object versioning - fall back
to listing without versions.

Signed-off-by: Andrew Gaul <andrew@gaul.org>