### PR TITLE
bootstrap: yum install the list of dependencies

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -15,16 +15,7 @@ if [ -f /etc/debian_version ]; then
     fi
 fi
 if [ -f /etc/redhat-release ]; then
-    for package in python-pip python-virtualenv python-devel libevent-devel; do
-        if [ "$(rpm -qa $package 2>/dev/null)" == "" ]; then
-            missing="${missing:+$missing }$package"
-        fi
-    done
-    if [ -n "$missing" ]; then
-        echo "$0: missing required packages, please install them:" 1>&2
-        echo "  sudo yum install $missing"
-        exit 1
-    fi
+    sudo yum install python-pip python-virtualenv python-devel libevent-devel
 fi
 
 virtualenv --no-site-packages --distribute virtualenv


### PR DESCRIPTION
This optimizes the bootstrap section for RPM in a couple ways:

1. There's no need to check "`rpm -q`" before doing "`yum install`". Yum will gracefully skip packages that are already installed.
2. Just assume that the user has sudo rights; don't "echo" what they should do. If there are problems, they can read the bootstrap shell script to figure out what's going on.
3. Handle all the packages at once; don't loop through them individually.

Related: http://tracker.ceph.com/issues/11637