### PR TITLE
bootstrap: apt/yum install the list of dependencies

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -9,9 +9,8 @@ if [ -f /etc/debian_version ]; then
         fi
     done
     if [ -n "$missing" ]; then
-        echo "$0: missing required packages, please install them:" 1>&2
-        echo "  sudo apt-get install $missing"
-        exit 1
+        echo "$0: missing required DEB packages. Installing via sudo." 1>&2
+        sudo apt-get -y install $missing
     fi
 fi
 if [ -f /etc/redhat-release ]; then
@@ -21,9 +20,8 @@ if [ -f /etc/redhat-release ]; then
         fi
     done
     if [ -n "$missing" ]; then
-        echo "$0: missing required packages, please install them:" 1>&2
-        echo "  sudo yum install $missing"
-        exit 1
+        echo "$0: missing required RPM packages. Installing via sudo." 1>&2
+        sudo yum -y install $missing
     fi
 fi
 


### PR DESCRIPTION
If RPM or DEB packages are missing, don't print to STDERR and bail. Instead, assume that the user has sudo rights, and attempt to install the missing packages for the user automatically.

CC'ing @andrewgaul in case he wants to review.