### PR TITLE
Remove unneeded called to _head_bucket

### DIFF
--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -4635,8 +4635,6 @@ def _check_upload_multipart_resend(bucket, key, objlen, resend_parts):
     (upload, data) = _multipart_upload(bucket, key, objlen, headers={'Content-Type': content_type}, metadata={'foo': 'bar'}, resend_parts=resend_parts)
     upload.complete_upload()
 
-    (obj_count, bytes_used) = _head_bucket(bucket)
-
     k=bucket.get_key(key)
     eq(k.metadata['foo'], 'bar')
     eq(k.content_type, content_type)


### PR DESCRIPTION
Test does not consume obj_count or bytes_used and this function now
returns a dict of optional headers.

Signed-off-by: Andrew Gaul <andrew@gaul.org>