### PR TITLE
Improve proxy error support: "Bad Request" case

### DIFF
--- a/s3tests/functional/test_headers.py
+++ b/s3tests/functional/test_headers.py
@@ -170,7 +170,7 @@ def test_object_create_bad_md5_invalid():
 
     e = assert_raises(boto.exception.S3ResponseError, key.set_contents_from_string, 'bar')
     eq(e.status, 400)
-    eq(e.reason, 'Bad Request')
+    eq(e.reason.lower(), 'bad request') # some proxies vary the case
     eq(e.error_code, 'InvalidDigest')
 
 
@@ -184,7 +184,7 @@ def test_object_create_bad_md5_wrong():
 
     e = assert_raises(boto.exception.S3ResponseError, key.set_contents_from_string, 'bar')
     eq(e.status, 400)
-    eq(e.reason, 'Bad Request')
+    eq(e.reason.lower(), 'bad request') # some proxies vary the case
     eq(e.error_code, 'InvalidDigest')
 
 
@@ -198,7 +198,7 @@ def test_object_create_bad_md5_empty():
 
     e = assert_raises(boto.exception.S3ResponseError, key.set_contents_from_string, 'bar')
     eq(e.status, 400)
-    eq(e.reason, 'Bad Request')
+    eq(e.reason.lower(), 'bad request') # some proxies vary the case
     eq(e.error_code, 'InvalidDigest')
 
 
@@ -284,7 +284,7 @@ def test_object_create_bad_contentlength_empty():
 
     e = assert_raises(boto.exception.S3ResponseError, key.set_contents_from_string, 'bar')
     eq(e.status, 400)
-    eq(e.reason, 'Bad Request')
+    eq(e.reason.lower(), 'bad request') # some proxies vary the case
     eq(e.error_code, None)
 
 
@@ -298,7 +298,7 @@ def test_object_create_bad_contentlength_negative():
 
     e = assert_raises(boto.exception.S3ResponseError, key.set_contents_from_string, 'bar')
     eq(e.status, 400)
-    eq(e.reason, 'Bad Request')
+    eq(e.reason.lower(), 'bad request') # some proxies vary the case
 
 
 @attr(resource='object')
@@ -324,7 +324,7 @@ def test_object_create_bad_contentlength_unreadable():
 
     e = assert_raises(boto.exception.S3ResponseError, key.set_contents_from_string, 'bar')
     eq(e.status, 400)
-    eq(e.reason, 'Bad Request')
+    eq(e.reason.lower(), 'bad request') # some proxies vary the case
     eq(e.error_code, None)
 
 
@@ -342,7 +342,7 @@ def test_object_create_bad_contentlength_mismatch_above():
 
     e = assert_raises(boto.exception.S3ResponseError, key.set_contents_from_string, content)
     eq(e.status, 400)
-    eq(e.reason, 'Bad Request')
+    eq(e.reason.lower(), 'bad request') # some proxies vary the case
     eq(e.error_code, 'RequestTimeout')
 
 
@@ -358,8 +358,7 @@ def test_object_create_bad_contentlength_mismatch_below():
 
     e = assert_raises(boto.exception.S3ResponseError, key.set_contents_from_string, content)
     eq(e.status, 400)
-    # dho is 'Bad request', which doesn't match the http response code
-    eq(e.reason, 'Bad Request')
+    eq(e.reason.lower(), 'bad request') # some proxies vary the case
     eq(e.error_code, 'BadDigest')
 
 
@@ -448,7 +447,7 @@ def test_object_create_bad_authorization_invalid():
 
     e = assert_raises(boto.exception.S3ResponseError, key.set_contents_from_string, 'bar')
     eq(e.status, 400)
-    eq(e.reason, 'Bad Request')
+    eq(e.reason.lower(), 'bad request') # some proxies vary the case
     eq(e.error_code, 'InvalidArgument')
 
 
@@ -721,7 +720,7 @@ def test_bucket_create_bad_contentlength_empty():
     e = assert_raises(boto.exception.S3ResponseError, get_new_bucket, conn)
 
     eq(e.status, 400)
-    eq(e.reason, 'Bad Request')
+    eq(e.reason.lower(), 'bad request') # some proxies vary the case
     eq(e.error_code, None)
 
 
@@ -734,7 +733,7 @@ def test_bucket_create_bad_contentlength_negative():
     _add_custom_headers({'Content-Length': -1})
     e = assert_raises(boto.exception.S3ResponseError, get_new_bucket)
     eq(e.status, 400)
-    eq(e.reason, 'Bad Request')
+    eq(e.reason.lower(), 'bad request') # some proxies vary the case
 
 
 @attr(resource='bucket')
@@ -757,7 +756,7 @@ def test_bucket_create_bad_contentlength_unreadable():
     e = assert_raises(boto.exception.S3ResponseError, get_new_bucket)
 
     eq(e.status, 400)
-    eq(e.reason, 'Bad Request')
+    eq(e.reason.lower(), 'bad request') # some proxies vary the case
     eq(e.error_code, None)
 
 
@@ -801,7 +800,7 @@ def test_bucket_create_bad_authorization_invalid():
     e = assert_raises(boto.exception.S3ResponseError, get_new_bucket)
 
     eq(e.status, 400)
-    eq(e.reason, 'Bad Request')
+    eq(e.reason.lower(), 'bad request') # some proxies vary the case
     eq(e.error_code, 'InvalidArgument')
 
 

--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -558,7 +558,7 @@ def test_bucket_list_maxkeys_invalid():
 
     e = assert_raises(boto.exception.S3ResponseError, bucket.get_all_keys, max_keys='blah')
     eq(e.status, 400)
-    eq(e.reason, 'Bad Request')
+    eq(e.reason.lower(), 'bad request') # some proxies vary the case
     eq(e.error_code, 'InvalidArgument')
 
 
@@ -572,7 +572,7 @@ def test_bucket_list_maxkeys_unreadable():
 
     e = assert_raises(boto.exception.S3ResponseError, bucket.get_all_keys, max_keys='\x0a')
     eq(e.status, 400)
-    eq(e.reason, 'Bad Request')
+    eq(e.reason.lower(), 'bad request') # some proxies vary the case
     # Weird because you can clearly see an InvalidArgument error code. What's
     # also funny is the Amazon tells us that it's not an interger or within an
     # integer range. Is 'blah' in the integer range?
@@ -2585,7 +2585,7 @@ def check_bad_bucket_name(name):
     """
     e = assert_raises(boto.exception.S3ResponseError, get_new_bucket, targets.main.default, name)
     eq(e.status, 400)
-    eq(e.reason, 'Bad Request')
+    eq(e.reason.lower(), 'bad request') # some proxies vary the case
     eq(e.error_code, 'InvalidBucketName')
 
 
@@ -3641,7 +3641,7 @@ def test_bucket_acl_grant_nonexist_user():
     print policy.to_xml()
     e = assert_raises(boto.exception.S3ResponseError, bucket.set_acl, policy)
     eq(e.status, 400)
-    eq(e.reason, 'Bad Request')
+    eq(e.reason.lower(), 'bad request') # some proxies vary the case
     eq(e.error_code, 'InvalidArgument')
 
 
@@ -3867,7 +3867,7 @@ def test_bucket_acl_grant_email_notexist():
     policy.acl.add_email_grant('FULL_CONTROL', NONEXISTENT_EMAIL)
     e = assert_raises(boto.exception.S3ResponseError, bucket.set_acl, policy)
     eq(e.status, 400)
-    eq(e.reason, 'Bad Request')
+    eq(e.reason.lower(), 'bad request') # some proxies vary the case
     eq(e.error_code, 'UnresolvableGrantByEmailAddress')
 
 
@@ -4287,7 +4287,7 @@ def test_object_copy_to_itself():
     key.set_contents_from_string('foo')
     e = assert_raises(boto.exception.S3ResponseError, key.copy, bucket, 'foo123bar')
     eq(e.status, 400)
-    eq(e.reason, 'Bad Request')
+    eq(e.reason.lower(), 'bad request') # some proxies vary the case
     eq(e.error_code, 'InvalidRequest')
 
 @attr(resource='object')


### PR DESCRIPTION
If you are run the S3 testsuite against a reverse proxy (eg haproxy)
rather than RGW directly, some of the tests will return errors from the
proxy, rather than haproxy itself.

Some proxies differ from RGW in the exact case of 'Bad Request', so do
the match in a case-insensitive manner. Haproxy for example returns 'Bad
request'.

This removes the need for some of the prior fails_on_dho test tags, as
the failure was due to haproxy.

Signed-off-by: Robin H. Johnson <robin.johnson@dreamhost.com>
(cherry picked from commit 76a6d88bfd016817e0366e437e9fb38f90f8cdac)