### PR TITLE
Add test for COPY Content-Type header

### DIFF
--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -4461,6 +4461,21 @@ def test_object_copy_same_bucket():
     key2 = bucket.get_key('bar321foo')
     eq(key2.get_contents_as_string(), 'foo')
 
+# http://tracker.ceph.com/issues/11563
+@attr(resource='object')
+@attr(method='put')
+@attr(operation='copy object with content-type')
+@attr(assertion='works')
+def test_object_copy_verify_contenttype():
+    bucket = get_new_bucket()
+    key = bucket.new_key('foo123bar')
+    content_type = 'text/bla'
+    key.set_contents_from_string('foo',headers={'Content-Type': content_type})
+    key.copy(bucket, 'bar321foo')
+    key2 = bucket.get_key('bar321foo')
+    eq(key2.get_contents_as_string(), 'foo')
+    eq(key2.content_type, content_type)
+
 @attr(resource='object')
 @attr(method='put')
 @attr(operation='copy object to itself')


### PR DESCRIPTION
Issue #11563 deals with the COPY command breaking the Content-Type
header. Add a test case for this to ensure it remains fixed.

Reference: http://tracker.ceph.com/issues/11563
Signed-off-by: Robin H. Johnson <robin.johnson@dreamhost.com>