### PR TITLE
s3tests: do not exit cleanup after first bucket!

### DIFF
--- a/s3tests/functional/__init__.py
+++ b/s3tests/functional/__init__.py
@@ -98,7 +98,7 @@ def nuke_prefixed_buckets_on_conn(prefix, name, conn):
                     pass
 
                 if success:
-                    return
+                    break
 
                 bucket.set_canned_acl('private')
 


### PR DESCRIPTION
Bucket cleanup code was exiting after the first succesful bucket
removed, instead of cleaning up all buckets. This left many buckets
behind over time, causing large slowdowns of the test suite.

This was introduced in commit c41ebab9cf93617f06084cf88c297188b4aa9f67,
when changes for versioned files were added.

Signed-off-by: Kobi Laredo <kobi.laredo@dreamhost.com>
Signed-off-by: Robin H. Johnson <robin.johnson@dreamhost.com>
Backport: hammer