### PR TITLE
Static website testsuites

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ requests ==0.14.0
 pytz >=2011k
 ordereddict
 httplib2
+lxml

--- a/s3tests/common.py
+++ b/s3tests/common.py
@@ -259,6 +259,9 @@ def with_setup_kwargs(setup, teardown=None):
 
 
 def normalize_xml(xml, pretty_print=True):
+    if xml is None:
+        return xml
+
     root = etree.fromstring(xml.encode(encoding='ascii'))
 
     for element in root.iter('*'):
@@ -285,6 +288,9 @@ def normalize_xml(xml, pretty_print=True):
     return xmlstr
 
 def assert_xml_equal(got, want):
+    assert want is not None, 'Wanted XML cannot be None'
+    if got is None:
+        raise AssertionError('Got input to validate was None')
     checker = LXMLOutputChecker()
     if not checker.check_output(want, got, 0):
         message = checker.output_difference(Example("", want), got, 0)

--- a/s3tests/common.py
+++ b/s3tests/common.py
@@ -258,7 +258,7 @@ def with_setup_kwargs(setup, teardown=None):
 #    yield _test_gen
 
 
-def normalize_xml_whitespace(xml, pretty_print=True):
+def normalize_xml(xml, pretty_print=True):
     root = etree.fromstring(xml.encode(encoding='ascii'))
 
     for element in root.iter('*'):
@@ -271,10 +271,14 @@ def normalize_xml_whitespace(xml, pretty_print=True):
         if element.tail is not None:
             element.tail = element.tail.strip().replace("\n", "").replace("\r", "")
 
+    # Sort the elements
+    for parent in root.xpath('//*[./*]'): # Search for parent elements
+          parent[:] = sorted(parent,key=lambda x: x.tag)
+
     xmlstr = etree.tostring(root, encoding="utf-8", xml_declaration=True, pretty_print=pretty_print)
     # there are two different DTD URIs
-    xmlstr = re.sub(r'xmlns="[^"]+"', 'xmlns="DTD-URI"', xmlstr)
-    xmlstr = re.sub(r'xmlns=\'[^\']+\'', 'xmlns="DTD-URI"', xmlstr)
+    xmlstr = re.sub(r'xmlns="[^"]+"', 'xmlns="s3"', xmlstr)
+    xmlstr = re.sub(r'xmlns=\'[^\']+\'', 'xmlns="s3"', xmlstr)
     for uri in ['http://doc.s3.amazonaws.com/doc/2006-03-01/', 'http://s3.amazonaws.com/doc/2006-03-01/']:
         xmlstr = xmlstr.replace(uri, 'URI-DTD')
     #xmlstr = re.sub(r'>\s+', '>', xmlstr, count=0, flags=re.MULTILINE)

--- a/s3tests/common.py
+++ b/s3tests/common.py
@@ -5,6 +5,7 @@ import os
 import random
 import string
 import yaml
+from lxml import etree
 
 s3 = bunch.Bunch()
 config = bunch.Bunch()
@@ -251,3 +252,19 @@ def with_setup_kwargs(setup, teardown=None):
 #def test_gen():
 #    yield _test_gen, '1'
 #    yield _test_gen
+
+
+def normalize_xml_whitespace(xml, pretty_print=True):
+    root = etree.fromstring(xml.encode(encoding='ascii'))
+
+    for element in root.iter('*'):
+        if element.text is not None and not element.text.strip():
+            element.text = None
+        if element.text is not None:
+            element.text = element.text.strip().replace("\n","").replace("\r","")
+        if element.tail is not None and not element.tail.strip():
+            element.tail = None
+        if element.tail is not None:
+            element.tail = element.tail.strip().replace("\n","").replace("\r","")
+
+    return etree.tostring(root, encoding="utf-8", xml_declaration=True, pretty_print=pretty_print)

--- a/s3tests/common.py
+++ b/s3tests/common.py
@@ -257,6 +257,10 @@ def with_setup_kwargs(setup, teardown=None):
 #    yield _test_gen, '1'
 #    yield _test_gen
 
+def trim_xml(xml_str):
+    p = etree.XMLParser(remove_blank_text=True)
+    elem = etree.XML(xml_str, parser=p)
+    return etree.tostring(elem)
 
 def normalize_xml(xml, pretty_print=True):
     if xml is None:

--- a/s3tests/functional/__init__.py
+++ b/s3tests/functional/__init__.py
@@ -401,7 +401,7 @@ def get_new_bucket(target=None, name=None, headers=None):
     bucket = connection.create_bucket(name, location=target.conf.api_name, headers=headers)
     return bucket
 
-def _make_request(method, bucket, key, body=None, authenticated=False, response_headers=None, request_headers=None, expires_in=100000, path_style=True):
+def _make_request(method, bucket, key, body=None, authenticated=False, response_headers=None, request_headers=None, expires_in=100000, path_style=True, timeout=None):
     """
     issue a request for a specified method, on a specified <bucket,key>,
     with a specified (optional) body (encrypted per the connection), and
@@ -425,9 +425,9 @@ def _make_request(method, bucket, key, body=None, authenticated=False, response_
         else:
             path = '/{obj}'.format(bucket=key.bucket.name, obj=key.name)
 
-    return _make_raw_request(host=s3.main.host, port=s3.main.port, method=method, path=path, body=body, request_headers=request_headers, secure=s3.main.is_secure)
+    return _make_raw_request(host=s3.main.host, port=s3.main.port, method=method, path=path, body=body, request_headers=request_headers, secure=s3.main.is_secure, timeout=timeout)
 
-def _make_bucket_request(method, bucket, body=None, authenticated=False, response_headers=None, request_headers=None, expires_in=100000, path_style=True):
+def _make_bucket_request(method, bucket, body=None, authenticated=False, response_headers=None, request_headers=None, expires_in=100000, path_style=True, timeout=None):
     """
     issue a request for a specified method, on a specified <bucket,key>,
     with a specified (optional) body (encrypted per the connection), and
@@ -451,9 +451,9 @@ def _make_bucket_request(method, bucket, body=None, authenticated=False, respons
         else:
             path = '/'
 
-    return _make_raw_request(host=s3.main.host, port=s3.main.port, method=method, path=path, body=body, request_headers=request_headers, secure=s3.main.is_secure)
+    return _make_raw_request(host=s3.main.host, port=s3.main.port, method=method, path=path, body=body, request_headers=request_headers, secure=s3.main.is_secure, timeout=timeout)
 
-def _make_raw_request(host, port, method, path, body=None, request_headers=None, secure=False):
+def _make_raw_request(host, port, method, path, body=None, request_headers=None, secure=False, timeout=None):
     if secure:
         class_ = HTTPSConnection
     else:
@@ -464,7 +464,7 @@ def _make_raw_request(host, port, method, path, body=None, request_headers=None,
 
     skip_host=('Host' in request_headers)
     skip_accept_encoding = False
-    c = class_(host, port, strict=True)
+    c = class_(host, port, strict=True, timeout=timeout)
 
     # We do the request manually, so we can muck with headers
     #c.request(method, path, body=body, headers=request_headers)

--- a/s3tests/functional/__init__.py
+++ b/s3tests/functional/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+import sys
 import ConfigParser
 import boto.exception
 import boto.s3.connection
@@ -55,15 +57,15 @@ def choose_bucket_prefix(template, max_len=30):
 
 
 def nuke_prefixed_buckets_on_conn(prefix, name, conn):
-    print 'Cleaning buckets from connection {name} prefix {prefix!r}.'.format(
+    print('Cleaning buckets from connection {name} prefix {prefix!r}.'.format(
         name=name,
         prefix=prefix,
-        )
+        ))
 
     for bucket in conn.get_all_buckets():
-        print 'prefix=',prefix
+        print('prefix=',prefix)
         if bucket.name.startswith(prefix):
-            print 'Cleaning bucket {bucket}'.format(bucket=bucket)
+            print('Cleaning bucket {bucket}'.format(bucket=bucket))
             success = False
             for i in xrange(2):
                 try:
@@ -81,17 +83,17 @@ def nuke_prefixed_buckets_on_conn(prefix, name, conn):
                             raise e
                         keys = bucket.list();
                     for key in keys:
-                        print 'Cleaning bucket {bucket} key {key}'.format(
+                        print('Cleaning bucket {bucket} key {key}'.format(
                             bucket=bucket,
                             key=key,
-                            )
+                            ))
                         # key.set_canned_acl('private')
                         bucket.delete_key(key.name, version_id = key.version_id)
                     bucket.delete()
                     success = True
                 except boto.exception.S3ResponseError as e:
                     if e.error_code != 'AccessDenied':
-                        print 'GOT UNWANTED ERROR', e.error_code
+                        print('GOT UNWANTED ERROR', e.error_code)
                         raise
                     # seems like we don't have permissions set appropriately, we'll
                     # modify permissions and retry
@@ -107,26 +109,26 @@ def nuke_prefixed_buckets(prefix):
     # If no regions are specified, use the simple method
     if targets.main.master == None:
         for name, conn in s3.items():
-            print 'Deleting buckets on {name}'.format(name=name)
+            print('Deleting buckets on {name}'.format(name=name))
             nuke_prefixed_buckets_on_conn(prefix, name, conn)
     else: 
 		    # First, delete all buckets on the master connection 
 		    for name, conn in s3.items():
 		        if conn == targets.main.master.connection:
-		            print 'Deleting buckets on {name} (master)'.format(name=name)
+		            print('Deleting buckets on {name} (master)'.format(name=name))
 		            nuke_prefixed_buckets_on_conn(prefix, name, conn)
 		
 		    # Then sync to propagate deletes to secondaries
 		    region_sync_meta(targets.main, targets.main.master.connection)
-		    print 'region-sync in nuke_prefixed_buckets'
+		    print('region-sync in nuke_prefixed_buckets')
 		
 		    # Now delete remaining buckets on any other connection 
 		    for name, conn in s3.items():
 		        if conn != targets.main.master.connection:
-		            print 'Deleting buckets on {name} (non-master)'.format(name=name)
+		            print('Deleting buckets on {name} (non-master)'.format(name=name))
 		            nuke_prefixed_buckets_on_conn(prefix, name, conn)
 
-    print 'Done with cleanup of test buckets.'
+    print('Done with cleanup of test buckets.')
 
 class TargetConfig:
     def __init__(self, cfg, section):

--- a/s3tests/functional/__init__.py
+++ b/s3tests/functional/__init__.py
@@ -408,11 +408,10 @@ def _make_request(method, bucket, key, body=None, authenticated=False, response_
     return the response (status, reason).
 
     If key is None, then this will be treated as a bucket-level request.
+
+    If the request or response headers are None, then default values will be
+    provided by later methods.
     """
-    if response_headers is None:
-        response_headers = {}
-    if request_headers is None:
-        request_headers = {}
     if not path_style:
         conn = bucket.connection
         request_headers['Host'] = conn.calling_format.build_host(conn.server_name(), bucket.name)
@@ -468,17 +467,11 @@ def _make_raw_request(host, port, method, path, body=None, request_headers=None,
     if request_headers is None:
         request_headers = {}
 
-    skip_host=('Host' in request_headers)
-    skip_accept_encoding = False
     c = class_(host, port, strict=True, timeout=timeout)
 
-    # We do the request manually, so we can muck with headers
-    #c.request(method, path, body=body, headers=request_headers)
-    c.connect()
-    c.putrequest(method, path, skip_host, skip_accept_encoding)
-    for k,v in request_headers.items():
-        c.putheader(k,v)
-    c.endheaders(message_body=body)
+    # TODO: We might have to modify this in future if we need to interact with
+    # how httplib.request handles Accept-Encoding and Host.
+    c.request(method, path, body=body, headers=request_headers)
 
     res = c.getresponse()
     #c.close()

--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -2886,6 +2886,7 @@ def _test_bucket_create_naming_good_long(length):
 @attr(method='put')
 @attr(operation='create w/250 byte name')
 @attr(assertion='fails with subdomain')
+@attr('fails_on_aws') # <Error><Code>InvalidBucketName</Code><Message>The specified bucket is not valid.</Message>...</Error>
 def test_bucket_create_naming_good_long_250():
     _test_bucket_create_naming_good_long(250)
 
@@ -2896,6 +2897,7 @@ def test_bucket_create_naming_good_long_250():
 @attr(method='put')
 @attr(operation='create w/251 byte name')
 @attr(assertion='fails with subdomain')
+@attr('fails_on_aws') # <Error><Code>InvalidBucketName</Code><Message>The specified bucket is not valid.</Message>...</Error>
 def test_bucket_create_naming_good_long_251():
     _test_bucket_create_naming_good_long(251)
 
@@ -2906,6 +2908,7 @@ def test_bucket_create_naming_good_long_251():
 @attr(method='put')
 @attr(operation='create w/252 byte name')
 @attr(assertion='fails with subdomain')
+@attr('fails_on_aws') # <Error><Code>InvalidBucketName</Code><Message>The specified bucket is not valid.</Message>...</Error>
 def test_bucket_create_naming_good_long_252():
     _test_bucket_create_naming_good_long(252)
 
@@ -2945,6 +2948,7 @@ def test_bucket_create_naming_good_long_255():
 @attr(method='get')
 @attr(operation='list w/251 byte name')
 @attr(assertion='fails with subdomain')
+@attr('fails_on_aws') # <Error><Code>InvalidBucketName</Code><Message>The specified bucket is not valid.</Message>...</Error>
 def test_bucket_list_long_name():
     prefix = get_new_bucket_name()
     length = 251
@@ -2985,6 +2989,7 @@ def test_bucket_create_naming_bad_punctuation():
 @attr(method='put')
 @attr(operation='create w/underscore in name')
 @attr(assertion='succeeds')
+@attr('fails_on_aws') # <Error><Code>InvalidBucketName</Code><Message>The specified bucket is not valid.</Message>...</Error>
 def test_bucket_create_naming_dns_underscore():
     check_good_bucket_name('foo_bar')
 
@@ -2995,6 +3000,7 @@ def test_bucket_create_naming_dns_underscore():
 @attr(method='put')
 @attr(operation='create w/100 byte name')
 @attr(assertion='fails with subdomain')
+@attr('fails_on_aws') # <Error><Code>InvalidBucketName</Code><Message>The specified bucket is not valid.</Message>...</Error>
 def test_bucket_create_naming_dns_long():
     prefix = get_prefix()
     assert len(prefix) < 50
@@ -3008,6 +3014,7 @@ def test_bucket_create_naming_dns_long():
 @attr(method='put')
 @attr(operation='create w/dash at end of name')
 @attr(assertion='fails with subdomain')
+@attr('fails_on_aws') # <Error><Code>InvalidBucketName</Code><Message>The specified bucket is not valid.</Message>...</Error>
 def test_bucket_create_naming_dns_dash_at_end():
     check_good_bucket_name('foo-')
 
@@ -3018,6 +3025,7 @@ def test_bucket_create_naming_dns_dash_at_end():
 @attr(method='put')
 @attr(operation='create w/.. in name')
 @attr(assertion='fails with subdomain')
+@attr('fails_on_aws') # <Error><Code>InvalidBucketName</Code><Message>The specified bucket is not valid.</Message>...</Error>
 def test_bucket_create_naming_dns_dot_dot():
     check_good_bucket_name('foo..bar')
 
@@ -3028,6 +3036,7 @@ def test_bucket_create_naming_dns_dot_dot():
 @attr(method='put')
 @attr(operation='create w/.- in name')
 @attr(assertion='fails with subdomain')
+@attr('fails_on_aws') # <Error><Code>InvalidBucketName</Code><Message>The specified bucket is not valid.</Message>...</Error>
 def test_bucket_create_naming_dns_dot_dash():
     check_good_bucket_name('foo.-bar')
 
@@ -3038,6 +3047,7 @@ def test_bucket_create_naming_dns_dot_dash():
 @attr(method='put')
 @attr(operation='create w/-. in name')
 @attr(assertion='fails with subdomain')
+@attr('fails_on_aws') # <Error><Code>InvalidBucketName</Code><Message>The specified bucket is not valid.</Message>...</Error>
 def test_bucket_create_naming_dns_dash_dot():
     check_good_bucket_name('foo-.bar')
 
@@ -3120,6 +3130,7 @@ def test_bucket_acl_default():
 @attr(method='get')
 @attr(operation='public-read acl')
 @attr(assertion='read back expected defaults')
+@attr('fails_on_aws') # <Error><Code>IllegalLocationConstraintException</Code><Message>The unspecified location constraint is incompatible for the region specific endpoint this request was sent to.</Message>
 def test_bucket_acl_canned_during_create():
     name = get_new_bucket_name()
     bucket = targets.main.default.connection.create_bucket(name, policy = 'public-read')
@@ -3548,6 +3559,7 @@ def test_object_acl_canned_bucketownerfullcontrol():
 @attr(method='put')
 @attr(operation='set write-acp')
 @attr(assertion='does not modify owner')
+@attr('fails_on_aws') #  <Error><Code>InvalidArgument</Code><Message>Invalid id</Message><ArgumentName>CanonicalUser/ID</ArgumentName><ArgumentValue>${ALTUSER}</ArgumentValue>
 def test_object_acl_full_control_verify_owner():
     bucket = get_new_bucket(targets.main.default)
     bucket.set_acl('public-read-write')
@@ -3638,6 +3650,7 @@ def _build_bucket_acl_xml(permission, bucket=None):
 @attr(method='ACLs')
 @attr(operation='set acl FULL_CONTROL (xml)')
 @attr(assertion='reads back correctly')
+@attr('fails_on_aws') #  <Error><Code>InvalidArgument</Code><Message>Invalid id</Message><ArgumentName>CanonicalUser/ID</ArgumentName><ArgumentValue>${USER}</ArgumentValue>
 def test_bucket_acl_xml_fullcontrol():
     _build_bucket_acl_xml('FULL_CONTROL')
 
@@ -3646,6 +3659,7 @@ def test_bucket_acl_xml_fullcontrol():
 @attr(method='ACLs')
 @attr(operation='set acl WRITE (xml)')
 @attr(assertion='reads back correctly')
+@attr('fails_on_aws') #  <Error><Code>InvalidArgument</Code><Message>Invalid id</Message><ArgumentName>CanonicalUser/ID</ArgumentName><ArgumentValue>${USER}</ArgumentValue>
 def test_bucket_acl_xml_write():
     _build_bucket_acl_xml('WRITE')
 
@@ -3654,6 +3668,7 @@ def test_bucket_acl_xml_write():
 @attr(method='ACLs')
 @attr(operation='set acl WRITE_ACP (xml)')
 @attr(assertion='reads back correctly')
+@attr('fails_on_aws') #  <Error><Code>InvalidArgument</Code><Message>Invalid id</Message><ArgumentName>CanonicalUser/ID</ArgumentName><ArgumentValue>${USER}</ArgumentValue>
 def test_bucket_acl_xml_writeacp():
     _build_bucket_acl_xml('WRITE_ACP')
 
@@ -3662,6 +3677,7 @@ def test_bucket_acl_xml_writeacp():
 @attr(method='ACLs')
 @attr(operation='set acl READ (xml)')
 @attr(assertion='reads back correctly')
+@attr('fails_on_aws') #  <Error><Code>InvalidArgument</Code><Message>Invalid id</Message><ArgumentName>CanonicalUser/ID</ArgumentName><ArgumentValue>${USER}</ArgumentValue>
 def test_bucket_acl_xml_read():
     _build_bucket_acl_xml('READ')
 
@@ -3670,6 +3686,7 @@ def test_bucket_acl_xml_read():
 @attr(method='ACLs')
 @attr(operation='set acl READ_ACP (xml)')
 @attr(assertion='reads back correctly')
+@attr('fails_on_aws') #  <Error><Code>InvalidArgument</Code><Message>Invalid id</Message><ArgumentName>CanonicalUser/ID</ArgumentName><ArgumentValue>${USER}</ArgumentValue>
 def test_bucket_acl_xml_readacp():
     _build_bucket_acl_xml('READ_ACP')
 
@@ -3708,6 +3725,7 @@ def _build_object_acl_xml(permission):
 @attr(method='ACLs')
 @attr(operation='set acl FULL_CONTROL (xml)')
 @attr(assertion='reads back correctly')
+@attr('fails_on_aws') #  <Error><Code>InvalidArgument</Code><Message>Invalid id</Message><ArgumentName>CanonicalUser/ID</ArgumentName><ArgumentValue>${USER}</ArgumentValue>
 def test_object_acl_xml():
     _build_object_acl_xml('FULL_CONTROL')
 
@@ -3716,6 +3734,7 @@ def test_object_acl_xml():
 @attr(method='ACLs')
 @attr(operation='set acl WRITE (xml)')
 @attr(assertion='reads back correctly')
+@attr('fails_on_aws') #  <Error><Code>InvalidArgument</Code><Message>Invalid id</Message><ArgumentName>CanonicalUser/ID</ArgumentName><ArgumentValue>${USER}</ArgumentValue>
 def test_object_acl_xml_write():
     _build_object_acl_xml('WRITE')
 
@@ -3724,6 +3743,7 @@ def test_object_acl_xml_write():
 @attr(method='ACLs')
 @attr(operation='set acl WRITE_ACP (xml)')
 @attr(assertion='reads back correctly')
+@attr('fails_on_aws') #  <Error><Code>InvalidArgument</Code><Message>Invalid id</Message><ArgumentName>CanonicalUser/ID</ArgumentName><ArgumentValue>${USER}</ArgumentValue>
 def test_object_acl_xml_writeacp():
     _build_object_acl_xml('WRITE_ACP')
 
@@ -3732,6 +3752,7 @@ def test_object_acl_xml_writeacp():
 @attr(method='ACLs')
 @attr(operation='set acl READ (xml)')
 @attr(assertion='reads back correctly')
+@attr('fails_on_aws') #  <Error><Code>InvalidArgument</Code><Message>Invalid id</Message><ArgumentName>CanonicalUser/ID</ArgumentName><ArgumentValue>${USER}</ArgumentValue>
 def test_object_acl_xml_read():
     _build_object_acl_xml('READ')
 
@@ -3740,6 +3761,7 @@ def test_object_acl_xml_read():
 @attr(method='ACLs')
 @attr(operation='set acl READ_ACP (xml)')
 @attr(assertion='reads back correctly')
+@attr('fails_on_aws') #  <Error><Code>InvalidArgument</Code><Message>Invalid id</Message><ArgumentName>CanonicalUser/ID</ArgumentName><ArgumentValue>${USER}</ArgumentValue>
 def test_object_acl_xml_readacp():
     _build_object_acl_xml('READ_ACP')
 
@@ -3848,6 +3870,7 @@ def _check_bucket_acl_grant_cant_writeacp(bucket):
 @attr(method='ACLs')
 @attr(operation='set acl w/userid FULL_CONTROL')
 @attr(assertion='can read/write data/acls')
+@attr('fails_on_aws') #  <Error><Code>InvalidArgument</Code><Message>Invalid id</Message><ArgumentName>CanonicalUser/ID</ArgumentName><ArgumentValue>${USER}</ArgumentValue>
 def test_bucket_acl_grant_userid_fullcontrol():
     bucket = _bucket_acl_grant_userid('FULL_CONTROL')
 
@@ -3871,6 +3894,7 @@ def test_bucket_acl_grant_userid_fullcontrol():
 @attr(method='ACLs')
 @attr(operation='set acl w/userid READ')
 @attr(assertion='can read data, no other r/w')
+@attr('fails_on_aws') #  <Error><Code>InvalidArgument</Code><Message>Invalid id</Message><ArgumentName>CanonicalUser/ID</ArgumentName><ArgumentValue>${ALTUSER}</ArgumentValue>
 def test_bucket_acl_grant_userid_read():
     bucket = _bucket_acl_grant_userid('READ')
 
@@ -3888,6 +3912,7 @@ def test_bucket_acl_grant_userid_read():
 @attr(method='ACLs')
 @attr(operation='set acl w/userid READ_ACP')
 @attr(assertion='can read acl, no other r/w')
+@attr('fails_on_aws') #  <Error><Code>InvalidArgument</Code><Message>Invalid id</Message><ArgumentName>CanonicalUser/ID</ArgumentName><ArgumentValue>${ALTUSER}</ArgumentValue>
 def test_bucket_acl_grant_userid_readacp():
     bucket = _bucket_acl_grant_userid('READ_ACP')
 
@@ -3905,6 +3930,7 @@ def test_bucket_acl_grant_userid_readacp():
 @attr(method='ACLs')
 @attr(operation='set acl w/userid WRITE')
 @attr(assertion='can write data, no other r/w')
+@attr('fails_on_aws') #  <Error><Code>InvalidArgument</Code><Message>Invalid id</Message><ArgumentName>CanonicalUser/ID</ArgumentName><ArgumentValue>${ALTUSER}</ArgumentValue>
 def test_bucket_acl_grant_userid_write():
     bucket = _bucket_acl_grant_userid('WRITE')
 
@@ -3922,6 +3948,7 @@ def test_bucket_acl_grant_userid_write():
 @attr(method='ACLs')
 @attr(operation='set acl w/userid WRITE_ACP')
 @attr(assertion='can write acls, no other r/w')
+@attr('fails_on_aws') #  <Error><Code>InvalidArgument</Code><Message>Invalid id</Message><ArgumentName>CanonicalUser/ID</ArgumentName><ArgumentValue>${ALTUSER}</ArgumentValue>
 def test_bucket_acl_grant_userid_writeacp():
     bucket = _bucket_acl_grant_userid('WRITE_ACP')
 
@@ -4005,6 +4032,7 @@ def _get_acl_header(user=None, perms=None):
 @attr(operation='add all grants to user through headers')
 @attr(assertion='adds all grants individually to second user')
 @attr('fails_on_dho')
+@attr('fails_on_aws') #  <Error><Code>InvalidArgument</Code><Message>Invalid id</Message><ArgumentName>CanonicalUser/ID</ArgumentName><ArgumentValue>${ALTUSER}</ArgumentValue>
 def test_object_header_acl_grants():
     bucket = get_new_bucket()
     headers = _get_acl_header()
@@ -4064,6 +4092,7 @@ def test_object_header_acl_grants():
 @attr(operation='add all grants to user through headers')
 @attr(assertion='adds all grants individually to second user')
 @attr('fails_on_dho')
+@attr('fails_on_aws') #  <Error><Code>InvalidArgument</Code><Message>Invalid id</Message><ArgumentName>CanonicalUser/ID</ArgumentName><ArgumentValue>${ALTUSER}</ArgumentValue>
 def test_bucket_header_acl_grants():
     headers = _get_acl_header()
     bucket = get_new_bucket(targets.main.default, get_prefix(), headers)
@@ -4128,6 +4157,7 @@ def test_bucket_header_acl_grants():
 @attr(method='ACLs')
 @attr(operation='add second FULL_CONTROL user')
 @attr(assertion='works for S3, fails for DHO')
+@attr('fails_on_aws') #  <Error><Code>AmbiguousGrantByEmailAddress</Code><Message>The e-mail address you provided is associated with more than one account. Please retry your request using a different identification method or after resolving the ambiguity.</Message>
 def test_bucket_acl_grant_email():
     bucket = get_new_bucket()
     # add alt user

--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -27,9 +27,6 @@ import re
 
 import xml.etree.ElementTree as ET
 
-from httplib import HTTPConnection, HTTPSConnection
-from urlparse import urlparse
-
 from nose.tools import eq_ as eq
 from nose.plugins.attrib import attr
 from nose.plugins.skip import SkipTest
@@ -53,6 +50,8 @@ from . import (
     config,
     get_prefix,
     is_slow_backend,
+    _make_request,
+    _make_bucket_request,
     )
 
 
@@ -2454,57 +2453,6 @@ def _setup_bucket_request(bucket_acl=None):
         bucket.set_acl(bucket_acl)
 
     return bucket
-
-def _make_request(method, bucket, key, body=None, authenticated=False, response_headers=None, expires_in=100000):
-    """
-    issue a request for a specified method, on a specified <bucket,key>,
-    with a specified (optional) body (encrypted per the connection), and
-    return the response (status, reason)
-    """
-    if authenticated:
-        url = key.generate_url(expires_in, method=method, response_headers=response_headers)
-        o = urlparse(url)
-        path = o.path + '?' + o.query
-    else:
-        path = '/{bucket}/{obj}'.format(bucket=key.bucket.name, obj=key.name)
-
-    if s3.main.is_secure:
-        class_ = HTTPSConnection
-    else:
-        class_ = HTTPConnection
-
-    c = class_(s3.main.host, s3.main.port, strict=True)
-    c.request(method, path, body=body)
-    res = c.getresponse()
-
-    print res.status, res.reason
-    return res
-
-def _make_bucket_request(method, bucket, body=None, authenticated=False, expires_in=100000):
-    """
-    issue a request for a specified method, on a specified <bucket,key>,
-    with a specified (optional) body (encrypted per the connection), and
-    return the response (status, reason)
-    """
-    if authenticated:
-        url = bucket.generate_url(expires_in, method=method)
-        o = urlparse(url)
-        path = o.path + '?' + o.query
-    else:
-        path = '/{bucket}'.format(bucket=bucket.name)
-
-    if s3.main.is_secure:
-        class_ = HTTPSConnection
-    else:
-        class_ = HTTPConnection
-
-    c = class_(s3.main.host, s3.main.port, strict=True)
-    c.request(method, path, body=body)
-    res = c.getresponse()
-
-    print res.status, res.reason
-    return res
-
 
 @attr(resource='object')
 @attr(method='get')

--- a/s3tests/functional/test_s3_website.py
+++ b/s3tests/functional/test_s3_website.py
@@ -790,10 +790,9 @@ def test_website_xredirect_nonwebsite():
     res = _website_request(bucket.name, '/page')
     body = res.read()
     print(body)
-    # RGW returns "302 Found" per RFC2616
-    # S3 returns 302 Moved Temporarily per RFC1945
-    #_website_expected_redirect_response(res, 302, ['Found', 'Moved Temporarily'], new_url)
-    expected_content = _website_expected_default_html(Code='NoSuchWebsiteConfiguration', BucketName=bucket.name, Message='The specified bucket does not have a website configuration')
+    expected_content = _website_expected_default_html(Code='NoSuchWebsiteConfiguration', BucketName=bucket.name)
+    # TODO: RGW does not have custom error messages for different 404s yet
+    #expected_content = _website_expected_default_html(Code='NoSuchWebsiteConfiguration', BucketName=bucket.name, Message='The specified bucket does not have a website configuration')
     print(expected_content)
     _website_expected_error_response(res, bucket.name, 404, 'Not Found', 'NoSuchWebsiteConfiguration', content=expected_content, body=body)
 

--- a/s3tests/functional/test_s3_website.py
+++ b/s3tests/functional/test_s3_website.py
@@ -60,7 +60,7 @@ def get_website_url(**kwargs):
 
     if hostname is None and bucket is None:
         return '/' + path.lstrip('/')
-    
+
     domain = config['main']['host']
     if('s3website_domain' in config['main']):
         domain = config['main']['s3website_domain']
@@ -91,7 +91,7 @@ def _test_website_prep(bucket, xml_template, hardcoded_fields = {}, expect_fail=
     if not xml_template:
         bucket.delete_website_configuration()
         return f
-    
+
     config_xmlnew = make_website_config(xml_fragment)
 
     config_xmlold = ''
@@ -385,7 +385,7 @@ def test_website_private_bucket_list_empty_missingerrordoc():
 
     res = _website_request(bucket.name, '')
     _website_expected_error_response(res, bucket.name, 403, 'Forbidden', 'AccessDenied', content=_website_expected_default_html(Code='AccessDenied'))
-    
+
     bucket.delete()
 
 @attr(resource='bucket')
@@ -980,43 +980,43 @@ ROUTING_RULES = {
 
 ROUTING_RULES_TESTS = [
   dict(xml=dict(RoutingRules=ROUTING_RULES['empty']), url='', location=None, code=200),
-  dict(xml=dict(RoutingRules=ROUTING_RULES['empty']), url='/', location=None, code=200), 
-  dict(xml=dict(RoutingRules=ROUTING_RULES['empty']), url='/x', location=None, code=404), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['empty']), url='/', location=None, code=200),
+  dict(xml=dict(RoutingRules=ROUTING_RULES['empty']), url='/x', location=None, code=404),
 
-  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1']), url='/', location=None, code=200), 
-  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1']), url='/x', location=None, code=404), 
-  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1']), url='/docs/', location=dict(proto='http',bucket='{bucket_name}',path='/documents/'), code=301), 
-  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1']), url='/docs/x', location=dict(proto='http',bucket='{bucket_name}',path='/documents/x'), code=301), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1']), url='/', location=None, code=200),
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1']), url='/x', location=None, code=404),
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1']), url='/docs/', location=dict(proto='http',bucket='{bucket_name}',path='/documents/'), code=301),
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1']), url='/docs/x', location=dict(proto='http',bucket='{bucket_name}',path='/documents/x'), code=301),
 
-  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=https']), url='/', location=None, code=200), 
-  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=https']), url='/x', location=None, code=404), 
-  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=https']), url='/docs/', location=dict(proto='https',bucket='{bucket_name}',path='/documents/'), code=301), 
-  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=https']), url='/docs/x', location=dict(proto='https',bucket='{bucket_name}',path='/documents/x'), code=301), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=https']), url='/', location=None, code=200),
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=https']), url='/x', location=None, code=404),
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=https']), url='/docs/', location=dict(proto='https',bucket='{bucket_name}',path='/documents/'), code=301),
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=https']), url='/docs/x', location=dict(proto='https',bucket='{bucket_name}',path='/documents/x'), code=301),
 
-  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=https+Hostname=xyzzy']), url='/', location=None, code=200), 
-  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=https+Hostname=xyzzy']), url='/x', location=None, code=404), 
-  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=https+Hostname=xyzzy']), url='/docs/', location=dict(proto='https',hostname='xyzzy',path='/documents/'), code=301), 
-  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=https+Hostname=xyzzy']), url='/docs/x', location=dict(proto='https',hostname='xyzzy',path='/documents/x'), code=301), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=https+Hostname=xyzzy']), url='/', location=None, code=200),
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=https+Hostname=xyzzy']), url='/x', location=None, code=404),
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=https+Hostname=xyzzy']), url='/docs/', location=dict(proto='https',hostname='xyzzy',path='/documents/'), code=301),
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=https+Hostname=xyzzy']), url='/docs/x', location=dict(proto='https',hostname='xyzzy',path='/documents/x'), code=301),
 
-  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample2']), url='/images/', location=dict(proto='http',bucket='{bucket_name}',path='/folderdeleted.html'), code=301), 
-  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample2']), url='/images/x', location=dict(proto='http',bucket='{bucket_name}',path='/folderdeleted.html'), code=301), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample2']), url='/images/', location=dict(proto='http',bucket='{bucket_name}',path='/folderdeleted.html'), code=301),
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample2']), url='/images/x', location=dict(proto='http',bucket='{bucket_name}',path='/folderdeleted.html'), code=301),
 
 
-  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample3']), url='/x', location=dict(proto='http',hostname='ec2-11-22-333-44.compute-1.amazonaws.com',path='/report-404/x'), code=301), 
-  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample3']), url='/images/x', location=dict(proto='http',hostname='ec2-11-22-333-44.compute-1.amazonaws.com',path='/report-404/images/x'), code=301), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample3']), url='/x', location=dict(proto='http',hostname='ec2-11-22-333-44.compute-1.amazonaws.com',path='/report-404/x'), code=301),
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample3']), url='/images/x', location=dict(proto='http',hostname='ec2-11-22-333-44.compute-1.amazonaws.com',path='/report-404/images/x'), code=301),
 
-  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample3+KeyPrefixEquals']), url='/x', location=None, code=404), 
-  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample3+KeyPrefixEquals']), url='/images/x', location=dict(proto='http',hostname='ec2-11-22-333-44.compute-1.amazonaws.com',path='/report-404/x'), code=301), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample3+KeyPrefixEquals']), url='/x', location=None, code=404),
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample3+KeyPrefixEquals']), url='/images/x', location=dict(proto='http',hostname='ec2-11-22-333-44.compute-1.amazonaws.com',path='/report-404/x'), code=301),
 ]
 
 ROUTING_ERROR_PROTOCOL = dict(code=400, reason='Bad Request', errorcode='InvalidRequest', bodyregex=r'Invalid protocol, protocol can be http or https. If not defined the protocol will be selected automatically.')
 
 ROUTING_RULES_TESTS_ERRORS = [
   # Invalid protocol, protocol can be http or https. If not defined the protocol will be selected automatically.
-  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=http2']), url='/', location=None, code=400, error=ROUTING_ERROR_PROTOCOL), 
-  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=http2']), url='/x', location=None, code=400, error=ROUTING_ERROR_PROTOCOL),  
-  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=http2']), url='/docs/', location=None, code=400, error=ROUTING_ERROR_PROTOCOL), 
-  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=http2']), url='/docs/x', location=None, code=400, error=ROUTING_ERROR_PROTOCOL), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=http2']), url='/', location=None, code=400, error=ROUTING_ERROR_PROTOCOL),
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=http2']), url='/x', location=None, code=400, error=ROUTING_ERROR_PROTOCOL),
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=http2']), url='/docs/', location=None, code=400, error=ROUTING_ERROR_PROTOCOL),
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=http2']), url='/docs/x', location=None, code=400, error=ROUTING_ERROR_PROTOCOL),
 ]
 
 VALID_AMZ_REDIRECT = set([301,302,303,304,305,307,308])
@@ -1111,6 +1111,3 @@ def test_routing_generator():
         if 'xml' in t and 'RoutingRules' in t['xml'] and len(t['xml']['RoutingRules']) > 0:
             t['xml']['RoutingRules'] = common.trim_xml(t['xml']['RoutingRules'])
         yield routing_check, t
-
-    
-

--- a/s3tests/functional/test_s3_website.py
+++ b/s3tests/functional/test_s3_website.py
@@ -884,7 +884,7 @@ def routing_check(*args, **kwargs):
     else:
         assert(False)
 
-@attr('xml')
+@attr('RoutingRules')
 def testGEN_routing():
 
     for t in ROUTING_RULES_TESTS:

--- a/s3tests/functional/test_s3_website.py
+++ b/s3tests/functional/test_s3_website.py
@@ -1136,7 +1136,7 @@ def routing_check(*args, **kwargs):
     else:
         assert(False)
 
-@attr('RoutingRules')
+@attr('s3website_RoutingRules')
 @attr('s3website')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_routing_generator():

--- a/s3tests/functional/test_s3_website.py
+++ b/s3tests/functional/test_s3_website.py
@@ -19,6 +19,8 @@ from . import (
     choose_bucket_prefix,
     )
 
+from ..common import with_setup_kwargs
+
 WEBSITE_CONFIGS_XMLFRAG = {
         'IndexDoc': '<IndexDocument><Suffix>${IndexDocument_Suffix}</Suffix></IndexDocument>',
         'IndexDocErrorDoc': '<IndexDocument><Suffix>${IndexDocument_Suffix}</Suffix></IndexDocument><ErrorDocument><Key>${ErrorDocument_Key}</Key></ErrorDocument>',

--- a/s3tests/functional/test_s3_website.py
+++ b/s3tests/functional/test_s3_website.py
@@ -4,6 +4,7 @@ import collections
 import nose
 import string
 import random
+from pprint import pprint
 
 from urlparse import urlparse
 
@@ -20,12 +21,15 @@ from . import (
     )
 
 from ..common import with_setup_kwargs
+from ..xmlhelper import normalize_xml_whitespace
+
+IGNORE_FIELD = 'IGNORETHIS'
 
 WEBSITE_CONFIGS_XMLFRAG = {
-        'IndexDoc': '<IndexDocument><Suffix>${IndexDocument_Suffix}</Suffix></IndexDocument>',
-        'IndexDocErrorDoc': '<IndexDocument><Suffix>${IndexDocument_Suffix}</Suffix></IndexDocument><ErrorDocument><Key>${ErrorDocument_Key}</Key></ErrorDocument>',
-        'RedirectAll': '<RedirectAllRequestsTo><HostName>${RedirectAllRequestsTo_HostName}</HostName></RedirectAllRequestsTo>',
-        'RedirectAll+Protocol': '<RedirectAllRequestsTo><HostName>${RedirectAllRequestsTo_HostName}</HostName><Protocol>${RedirectAllRequestsTo_Protocol}</Protocol></RedirectAllRequestsTo>',
+        'IndexDoc': '<IndexDocument><Suffix>${IndexDocument_Suffix}</Suffix></IndexDocument>${RoutingRules}',
+        'IndexDocErrorDoc': '<IndexDocument><Suffix>${IndexDocument_Suffix}</Suffix></IndexDocument><ErrorDocument><Key>${ErrorDocument_Key}</Key></ErrorDocument>${RoutingRules}',
+        'RedirectAll': '<RedirectAllRequestsTo><HostName>${RedirectAllRequestsTo_HostName}</HostName></RedirectAllRequestsTo>${RoutingRules}',
+        'RedirectAll+Protocol': '<RedirectAllRequestsTo><HostName>${RedirectAllRequestsTo_HostName}</HostName><Protocol>${RedirectAllRequestsTo_Protocol}</Protocol></RedirectAllRequestsTo>${RoutingRules}',
         }
 
 def make_website_config(xml_fragment):
@@ -34,23 +38,40 @@ def make_website_config(xml_fragment):
     """
     return '<?xml version="1.0" encoding="UTF-8"?><WebsiteConfiguration xmlns="http://doc.s3.amazonaws.com/doc/2006-03-01/">' + xml_fragment + '</WebsiteConfiguration>'
 
-def get_website_url(proto, bucket, path):
+def get_website_url(**kwargs):
     """
     Return the URL to a website page
     """
+    proto, bucket, hostname, path = 'http', None, None, '/'
+
+    if 'proto' in kwargs:
+        proto = kwargs['proto']
+    if 'bucket' in kwargs:
+        bucket = kwargs['bucket']
+    if 'hostname' in kwargs:
+        hostname = kwargs['hostname']
+    if 'path' in kwargs:
+        path = kwargs['path']
+    
     domain = config['main']['host']
     if('s3website_domain' in config['main']):
         domain = config['main']['s3website_domain']
     elif('s3website_domain' in config['alt']):
         domain = config['DEFAULT']['s3website_domain']
+    if hostname is None:
+        hostname = '%s.%s' % (bucket, domain)
     path = path.lstrip('/')
-    return "%s://%s.%s/%s" % (proto, bucket, domain, path)
+    return "%s://%s/%s" % (proto, hostname, path)
 
 def _test_website_populate_fragment(xml_fragment, fields):
+    for k in ['RoutingRules']:
+      if k in fields.keys() and len(fields[k]) > 0:
+         fields[k] = '<%s>%s</%s>' % (k, fields[k], k)
     f = {
           'IndexDocument_Suffix': choose_bucket_prefix(template='index-{random}.html', max_len=32),
           'ErrorDocument_Key': choose_bucket_prefix(template='error-{random}.html', max_len=32),
           'RedirectAllRequestsTo_HostName': choose_bucket_prefix(template='{random}.{random}.com', max_len=32),
+          'RoutingRules': ''
         }
     f.update(fields)
     xml_fragment = string.Template(xml_fragment).safe_substitute(**f)
@@ -58,10 +79,15 @@ def _test_website_populate_fragment(xml_fragment, fields):
 
 def _test_website_prep(bucket, xml_template, hardcoded_fields = {}):
     xml_fragment, f = _test_website_populate_fragment(xml_template, hardcoded_fields)
-    config_xml = make_website_config(xml_fragment)
-    print(config_xml)
-    bucket.set_website_configuration_xml(config_xml)
-    eq (config_xml, bucket.get_website_configuration_xml())
+    config_xml1 = make_website_config(xml_fragment)
+    bucket.set_website_configuration_xml(config_xml1)
+    config_xml1 = normalize_xml_whitespace(config_xml1, pretty_print=True) # Do it late, so the system gets weird whitespace
+    #print("config_xml1\n", config_xml1)
+    config_xml2 = bucket.get_website_configuration_xml()
+    config_xml2 = normalize_xml_whitespace(config_xml2, pretty_print=True) # For us to read
+    #print("config_xml2\n", config_xml2)
+    eq (config_xml1, config_xml2)
+    f['WebsiteConfiguration'] = config_xml2
     return f
 
 def __website_expected_reponse_status(res, status, reason):
@@ -70,15 +96,19 @@ def __website_expected_reponse_status(res, status, reason):
     if not isinstance(reason, collections.Container):
         reason = set([reason])
 
-    ok(res.status in status, 'HTTP status code mismatch')
-    ok(res.reason in reason, 'HTTP reason mismatch')
+    if status is not IGNORE_FIELD:
+        ok(res.status in status, 'HTTP code was %s should be %s' % (res.status, status))
+    if reason is not IGNORE_FIELD:
+        ok(res.reason in reason, 'HTTP reason was was %s should be %s' % (res.reason, reason))
 
 def _website_expected_error_response(res, bucket_name, status, reason, code):
     body = res.read()
     print(body)
     __website_expected_reponse_status(res, status, reason)
-    ok('<li>Code: '+code+'</li>' in body, 'HTML should contain "Code: %s" ' % (code, ))
-    ok(('<li>BucketName: %s</li>' % (bucket_name, )) in body, 'HTML should contain bucket name')
+    if code is not IGNORE_FIELD:
+        ok('<li>Code: '+code+'</li>' in body, 'HTML should contain "Code: %s" ' % (code, ))
+    if bucket_name is not IGNORE_FIELD:
+        ok(('<li>BucketName: %s</li>' % (bucket_name, )) in body, 'HTML should contain bucket name')
 
 def _website_expected_redirect_response(res, status, reason, new_url):
     body = res.read()
@@ -89,7 +119,7 @@ def _website_expected_redirect_response(res, status, reason, new_url):
     ok(len(body) == 0, 'Body of a redirect should be empty')
 
 def _website_request(bucket_name, path, method='GET'):
-    url = get_website_url('http', bucket_name, path)
+    url = get_website_url(proto='http', bucket=bucket_name, path=path)
     print("url", url)
 
     o = urlparse(url)
@@ -179,8 +209,8 @@ def test_website_private_bucket_list_public_index():
 @attr('s3website')
 def test_website_private_bucket_list_empty():
     bucket = get_new_bucket()
-    bucket.set_canned_acl('private')
     f = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDoc'])
+    bucket.set_canned_acl('private')
 
     res = _website_request(bucket.name, '')
     _website_expected_error_response(res, bucket.name, 403, 'Forbidden', 'AccessDenied')
@@ -517,8 +547,7 @@ def test_website_private_bucket_list_private_index_gooderrordoc():
     errorhtml.delete()
     bucket.delete()
 
-# ------ redirect tests
-
+# ------ RedirectAll tests
 @attr(resource='bucket')
 @attr(method='get')
 @attr(operation='list')
@@ -570,10 +599,212 @@ def test_website_bucket_private_redirectall_path_upgrade():
 
     pathfragment = choose_bucket_prefix(template='/{random}', max_len=16)
 
-    res = _website_request(bucket.name, +pathfragment)
+    res = _website_request(bucket.name, pathfragment)
     # RGW returns "302 Found" per RFC2616
     # S3 returns 302 Moved Temporarily per RFC1945
     new_url = 'https://%s%s' % (f['RedirectAllRequestsTo_HostName'], pathfragment)
     _website_expected_redirect_response(res, 302, ['Found', 'Moved Temporarily'], new_url)
 
     bucket.delete()
+
+# RoutingRules
+ROUTING_RULES = {
+    'empty': '',
+    'AmazonExample1': \
+"""
+    <RoutingRule>
+    <Condition>
+      <KeyPrefixEquals>docs/</KeyPrefixEquals>
+    </Condition>
+    <Redirect>
+      <ReplaceKeyPrefixWith>documents/</ReplaceKeyPrefixWith>
+    </Redirect>
+    </RoutingRule>
+""",
+    'AmazonExample1+Protocol=https': \
+"""
+    <RoutingRule>
+    <Condition>
+      <KeyPrefixEquals>docs/</KeyPrefixEquals>
+    </Condition>
+    <Redirect>
+      <Protocol>https</Protocol>
+      <ReplaceKeyPrefixWith>documents/</ReplaceKeyPrefixWith>
+    </Redirect>
+    </RoutingRule>
+""",
+    'AmazonExample1+Protocol=https+Hostname=xyzzy': \
+"""
+    <RoutingRule>
+    <Condition>
+      <KeyPrefixEquals>docs/</KeyPrefixEquals>
+    </Condition>
+    <Redirect>
+      <Protocol>https</Protocol>
+      <HostName>xyzzy</HostName>
+      <ReplaceKeyPrefixWith>documents/</ReplaceKeyPrefixWith>
+    </Redirect>
+    </RoutingRule>
+""",
+    'AmazonExample1+Protocol=http2': \
+"""
+    <RoutingRule>
+    <Condition>
+      <KeyPrefixEquals>docs/</KeyPrefixEquals>
+    </Condition>
+    <Redirect>
+      <Protocol>http2</Protocol>
+      <ReplaceKeyPrefixWith>documents/</ReplaceKeyPrefixWith>
+    </Redirect>
+    </RoutingRule>
+""",
+   'AmazonExample2': \
+"""
+    <RoutingRule>
+    <Condition>
+       <KeyPrefixEquals>images/</KeyPrefixEquals>
+    </Condition>
+    <Redirect>
+      <ReplaceKeyWith>folderdeleted.html</ReplaceKeyWith>
+    </Redirect>
+    </RoutingRule>
+""",
+   'AmazonExample2+HttpRedirectCode=314': \
+"""
+    <RoutingRule>
+    <Condition>
+       <KeyPrefixEquals>images/</KeyPrefixEquals>
+    </Condition>
+    <Redirect>
+      <HttpRedirectCode>314</HttpRedirectCode>
+      <ReplaceKeyWith>folderdeleted.html</ReplaceKeyWith>
+    </Redirect>
+    </RoutingRule>
+""",
+   'AmazonExample3': \
+"""
+    <RoutingRule>
+    <Condition>
+      <HttpErrorCodeReturnedEquals>404</HttpErrorCodeReturnedEquals >
+    </Condition>
+    <Redirect>
+      <HostName>ec2-11-22-333-44.compute-1.amazonaws.com</HostName>
+      <ReplaceKeyPrefixWith>report-404/</ReplaceKeyPrefixWith>
+    </Redirect>
+    </RoutingRule>
+""",
+   'AmazonExample3+KeyPrefixEquals': \
+"""
+    <RoutingRule>
+    <Condition>
+      <KeyPrefixEquals>images/</KeyPrefixEquals>
+      <HttpErrorCodeReturnedEquals>404</HttpErrorCodeReturnedEquals>
+    </Condition>
+    <Redirect>
+      <HostName>ec2-11-22-333-44.compute-1.amazonaws.com</HostName>
+      <ReplaceKeyPrefixWith>report-404/</ReplaceKeyPrefixWith>
+    </Redirect>
+    </RoutingRule>
+""",
+}
+
+ROUTING_RULES_TESTS = [
+  dict(xml=dict(RoutingRules=ROUTING_RULES['empty']), url='', location=None, code=200),
+  dict(xml=dict(RoutingRules=ROUTING_RULES['empty']), url='/', location=None, code=200), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['empty']), url='/x', location=None, code=404), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1']), url='/', location=None, code=200), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1']), url='/x', location=None, code=404), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1']), url='/docs/', location=dict(proto='http',bucket='{bucket_name}',path='/documents/'), code=301), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1']), url='/docs/x', location=dict(proto='http',bucket='{bucket_name}',path='/documents/x'), code=301), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=https']), url='/', location=None, code=200), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=https']), url='/x', location=None, code=404), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=https']), url='/docs/', location=dict(proto='https',bucket='{bucket_name}',path='/documents/'), code=301), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=https']), url='/docs/x', location=dict(proto='https',bucket='{bucket_name}',path='/documents/x'), code=301), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=http2']), url='/', location=None, code=200), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=http2']), url='/x', location=None, code=404), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=http2']), url='/docs/', location=dict(proto='http2',bucket='{bucket_name}',path='/documents/'), code=301), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=http2']), url='/docs/x', location=dict(proto='http2',bucket='{bucket_name}',path='/documents/x'), code=301), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=https+Hostname=xyzzy']), url='/', location=None, code=200), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=https+Hostname=xyzzy']), url='/x', location=None, code=404), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=https+Hostname=xyzzy']), url='/docs/', location=dict(proto='https',hostname='xyzzy',path='/documents/'), code=301), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=https+Hostname=xyzzy']), url='/docs/x', location=dict(proto='https',hostname='xyzzy',path='/documents/x'), code=301), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample2']), url='/images/', location=dict(proto='http',bucket='{bucket_name}',path='/folderdeleted.html'), code=301), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample2']), url='/images/x', location=dict(proto='http',bucket='{bucket_name}',path='/folderdeleted.html'), code=301), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample2+HttpRedirectCode=314']), url='/images/', location=dict(proto='http',bucket='{bucket_name}',path='/folderdeleted.html'), code=314), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample2+HttpRedirectCode=314']), url='/images/x', location=dict(proto='http',bucket='{bucket_name}',path='/folderdeleted.html'), code=314), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample3']), url='/x', location=dict(proto='http',bucket='ec2-11-22-333-44.compute-1.amazonaws.com',path='/report-404/x'), code=301), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample3']), url='/images/x', location=dict(proto='http',bucket='ec2-11-22-333-44.compute-1.amazonaws.com',path='/report-404/images/x'), code=301), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample3+KeyPrefixEquals']), url='/x', location=None, code=404), 
+  dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample3+KeyPrefixEquals']), url='/images/x', location=dict(proto='http',bucket='ec2-11-22-333-44.compute-1.amazonaws.com',path='/report-404/x'), code=301), 
+]
+
+def routing_setup():
+  kwargs = {'obj':[]}
+  bucket = get_new_bucket()
+  kwargs['bucket'] = bucket
+  kwargs['obj'].append(bucket)
+  f = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDocErrorDoc'])
+  kwargs.update(f)
+  bucket.set_canned_acl('public-read')
+
+  k = bucket.new_key(f['IndexDocument_Suffix'])
+  kwargs['obj'].append(k)
+  s = choose_bucket_prefix(template='<html><h1>Index</h1><body>{random}</body></html>', max_len=64)
+  k.set_contents_from_string(s)
+  k.set_canned_acl('public-read')
+
+  k = bucket.new_key(f['ErrorDocument_Key'])
+  kwargs['obj'].append(k)
+  s = choose_bucket_prefix(template='<html><h1>Error</h1><body>{random}</body></html>', max_len=64)
+  k.set_contents_from_string(s)
+  k.set_canned_acl('public-read')
+
+  return kwargs
+
+def routing_teardown(**kwargs):
+  for o in reversed(kwargs['obj']):
+    print('Deleting', str(o))
+    o.delete()
+  
+           
+@with_setup_kwargs(setup=routing_setup, teardown=routing_teardown) 
+def routing_check(*args, **kwargs):
+    bucket = kwargs['bucket']
+    args=args[0]
+    #print(args)
+    pprint(args)
+    xml_fields = kwargs.copy()
+    xml_fields.update(args['xml'])
+    pprint(xml_fields)
+    f = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDocErrorDoc'], hardcoded_fields=xml_fields)
+    #print(f)
+    config_xml2 = bucket.get_website_configuration_xml()
+    config_xml2 = normalize_xml_whitespace(config_xml2, pretty_print=True) # For us to read
+    res = _website_request(bucket.name, args['url'])
+    print(config_xml2)
+    # RGW returns "302 Found" per RFC2616
+    # S3 returns 302 Moved Temporarily per RFC1945
+    new_url = args['location']
+    if new_url is not None:
+        new_url = get_website_url(**new_url)
+        new_url = new_url.format(bucket_name=bucket.name)
+    if args['code'] >= 200 and args['code'] < 300:
+        #body = res.read()
+        #print(body)
+        #eq(body, args['content'], 'default content should match index.html set content')
+        ok(res.getheader('Content-Length', -1) > 0)
+    elif args['code'] >= 300 and args['code'] < 400:
+        _website_expected_redirect_response(res, args['code'], IGNORE_FIELD, new_url)
+    elif args['code'] >= 400:
+        _website_expected_error_response(res, bucket.name, args['code'], IGNORE_FIELD, IGNORE_FIELD)
+    else:
+        assert(False)
+
+@attr('xml')
+def testGEN_routing():
+
+    for t in ROUTING_RULES_TESTS:
+        yield routing_check, t
+
+    
+

--- a/s3tests/functional/test_s3_website.py
+++ b/s3tests/functional/test_s3_website.py
@@ -54,7 +54,7 @@ def check_can_test_website():
             elif e.status == 405 and e.reason == 'Method Not Allowed' and e.error_code == 'MethodNotAllowed':
                 # rgw_enable_static_website is false
                 CAN_WEBSITE = False
-            elif e.status == 403 and e.reason == 'SignatureDoesNotMatch':
+            elif e.status == 403 and e.reason == 'SignatureDoesNotMatch' and e.error_code == 'Forbidden':
                 # This is older versions that do not support the website code
                 CAN_WEBSITE = False
             else:

--- a/s3tests/functional/test_s3_website.py
+++ b/s3tests/functional/test_s3_website.py
@@ -1,50 +1,14 @@
 from __future__ import print_function
 import sys
-from cStringIO import StringIO
 import collections
-import boto.exception
-import boto.s3.connection
-import boto.s3.acl
-import bunch
-import datetime
-import time
-import email.utils
-import isodate
 import nose
-import operator
-import socket
-import ssl
-import os
-import requests
-import base64
-import hmac
-import sha
-import pytz
-import json
-import httplib2
-import threading
-import itertools
 import string
 import random
 
-import xml.etree.ElementTree as ET
-
-from httplib import HTTPConnection, HTTPSConnection
 from urlparse import urlparse
 
 from nose.tools import eq_ as eq, ok_ as ok
 from nose.plugins.attrib import attr
-from nose.plugins.skip import SkipTest
-
-from .utils import assert_raises
-from .utils import generate_random
-from .utils import region_sync_meta
-import AnonymousAuth
-
-from email.header import decode_header
-from ordereddict import OrderedDict
-
-from boto.s3.cors import CORSConfiguration
 
 from . import (
     get_new_bucket,

--- a/s3tests/functional/test_s3_website.py
+++ b/s3tests/functional/test_s3_website.py
@@ -547,12 +547,12 @@ def test_website_bucket_private_redirectall_path():
     f = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['RedirectAll'])
     bucket.set_canned_acl('private')
 
-    pathfragment = choose_bucket_prefix(template='{random}', max_len=16)
+    pathfragment = choose_bucket_prefix(template='/{random}', max_len=16)
 
-    res = _website_request(bucket.name, '/'+pathfragment)
+    res = _website_request(bucket.name, pathfragment)
     # RGW returns "302 Found" per RFC2616
     # S3 returns 302 Moved Temporarily per RFC1945
-    new_url = 'http://%s/%s' % (f['RedirectAllRequestsTo_HostName'], pathfragment)
+    new_url = 'http://%s%s' % (f['RedirectAllRequestsTo_HostName'], pathfragment)
     _website_expected_redirect_response(res, 302, ['Found', 'Moved Temporarily'], new_url)
 
     bucket.delete()
@@ -568,12 +568,12 @@ def test_website_bucket_private_redirectall_path_upgrade():
     f = _test_website_prep(bucket, x)
     bucket.set_canned_acl('private')
 
-    pathfragment = choose_bucket_prefix(template='{random}', max_len=16)
+    pathfragment = choose_bucket_prefix(template='/{random}', max_len=16)
 
-    res = _website_request(bucket.name, pathfragment)
+    res = _website_request(bucket.name, +pathfragment)
     # RGW returns "302 Found" per RFC2616
     # S3 returns 302 Moved Temporarily per RFC1945
-    new_url = 'https://%s/%s' % (f['RedirectAllRequestsTo_HostName'], pathfragment)
+    new_url = 'https://%s%s' % (f['RedirectAllRequestsTo_HostName'], pathfragment)
     _website_expected_redirect_response(res, 302, ['Found', 'Moved Temporarily'], new_url)
 
     bucket.delete()

--- a/s3tests/functional/test_s3_website.py
+++ b/s3tests/functional/test_s3_website.py
@@ -1,0 +1,525 @@
+from __future__ import print_function
+import sys
+from cStringIO import StringIO
+import boto.exception
+import boto.s3.connection
+import boto.s3.acl
+import bunch
+import datetime
+import time
+import email.utils
+import isodate
+import nose
+import operator
+import socket
+import ssl
+import os
+import requests
+import base64
+import hmac
+import sha
+import pytz
+import json
+import httplib2
+import threading
+import itertools
+import string
+import random
+
+import xml.etree.ElementTree as ET
+
+from httplib import HTTPConnection, HTTPSConnection
+from urlparse import urlparse
+
+from nose.tools import eq_ as eq, ok_ as ok
+from nose.plugins.attrib import attr
+from nose.plugins.skip import SkipTest
+
+from .utils import assert_raises
+from .utils import generate_random
+from .utils import region_sync_meta
+import AnonymousAuth
+
+from email.header import decode_header
+from ordereddict import OrderedDict
+
+from boto.s3.cors import CORSConfiguration
+
+from . import (
+    get_new_bucket,
+    get_new_bucket_name,
+    s3,
+    config,
+    _make_raw_request,
+    choose_bucket_prefix,
+    )
+
+WEBSITE_CONFIGS_XMLFRAG = {
+        'IndexDoc': '<IndexDocument><Suffix>{indexdoc}</Suffix></IndexDocument>',
+        'IndexDocErrorDoc': '<IndexDocument><Suffix>{indexdoc}</Suffix></IndexDocument><ErrorDocument><Key>{errordoc}</Key></ErrorDocument>',
+        }
+
+def make_website_config(xml_fragment):
+    """
+    Take the tedious stuff out of the config
+    """
+    return '<?xml version="1.0" encoding="UTF-8"?><WebsiteConfiguration xmlns="http://doc.s3.amazonaws.com/doc/2006-03-01/">' + xml_fragment + '</WebsiteConfiguration>'
+
+def get_website_url(proto, bucket, path):
+    """
+    Return the URL to a website page
+    """
+    domain = config['main']['host']
+    if('s3website_domain' in config['main']):
+        domain = config['main']['s3website_domain']
+    elif('s3website_domain' in config['alt']):
+        domain = config['DEFAULT']['s3website_domain']
+    return "%s://%s.%s/%s" % (proto, bucket, domain, path)
+
+def _test_website_prep(bucket, xml_fragment):
+    indexname = choose_bucket_prefix(template='index-{random}.html', max_len=32)
+    errorname = choose_bucket_prefix(template='error-{random}.html', max_len=32)
+    xml_fragment = xml_fragment.format(indexdoc=indexname, errordoc=errorname)
+    config_xml = make_website_config(xml_fragment)
+    bucket.set_website_configuration_xml(config_xml)
+    eq (config_xml, bucket.get_website_configuration_xml())
+    return indexname, errorname
+
+def __website_expected_reponse_status(res, status, reason):
+    eq(res.status, status)
+    eq(res.reason, reason)
+
+def _website_expected_error_response(res, bucket_name, status, reason, code):
+    body = res.read()
+    print(body)
+    __website_expected_reponse_status(res, status, reason)
+    ok('<li>Code: '+code+'</li>' in body, 'HTML should contain "Code: %s" ' % (code, ))
+    ok(('<li>BucketName: %s</li>' % (bucket_name, )) in body, 'HTML should contain bucket name')
+
+def _website_request(bucket_name, path):
+    url = get_website_url('http', bucket_name, path)
+    print("url", url)
+
+    o = urlparse(url)
+    path = o.path + '?' + o.query
+    request_headers={}
+    request_headers['Host'] = o.hostname
+    res = _make_raw_request(config.main.host, config.main.port, 'GET', path, request_headers=request_headers, secure=False)
+    for (k,v) in res.getheaders():
+        print(k,v)
+    return res
+
+# ---------- Non-existant buckets via the website endpoint
+@attr(resource='bucket')
+@attr(method='get')
+@attr(operation='list')
+@attr(assertion='non-existant bucket via website endpoint should give NoSuchBucket, exposing security risk')
+@attr('s3website')
+@attr('fails_on_rgw')
+def test_website_nonexistant_bucket_s3():
+    bucket_name = get_new_bucket_name()
+    res = _website_request(bucket_name, '')
+    _website_expected_error_response(res, bucket_name, 404, 'Not Found', 'NoSuchBucket')
+
+@attr(resource='bucket')
+@attr(method='get')
+@attr(operation='list')
+@attr(assertion='non-existant bucket via website endpoint should give Forbidden, keeping bucket identity secure')
+@attr('s3website')
+@attr('fails_on_s3')
+def test_website_nonexistant_bucket_rgw():
+    bucket_name = get_new_bucket_name()
+    res = _website_request(bucket_name, '')
+    _website_expected_error_response(res, bucket_name, 403, 'Forbidden', 'AccessDenied')
+
+#------------- IndexDocument only, successes
+@attr(resource='bucket')
+@attr(method='get')
+@attr(operation='list')
+@attr(assertion='non-empty public buckets via s3website return page for /, where page is public')
+@attr('s3website')
+def test_website_public_bucket_list_public_index():
+    bucket = get_new_bucket()
+    indexname, errorname = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDoc'])
+    bucket.make_public()
+    indexhtml = bucket.new_key(indexname)
+    indexstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    indexhtml.set_contents_from_string(indexstring)
+    indexhtml.make_public()
+
+    res = _website_request(bucket.name, '')
+    body = res.read()
+    print(body)
+    eq(body, indexstring, 'default content should match index.html set content')
+    __website_expected_reponse_status(res, 200, 'OK')
+    indexhtml.delete()
+    bucket.delete()
+
+@attr(resource='bucket')
+@attr(method='get')
+@attr(operation='list')
+@attr(assertion='non-empty private buckets via s3website return page for /, where page is private')
+@attr('s3website')
+def test_website_private_bucket_list_public_index():
+    bucket = get_new_bucket()
+    indexname, errorname = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDoc'])
+    bucket.set_canned_acl('private')
+    indexhtml = bucket.new_key(indexname)
+    indexstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    indexhtml.set_contents_from_string(indexstring)
+    indexhtml.make_public()
+
+    res = _website_request(bucket.name, '')
+    __website_expected_reponse_status(res, 200, 'OK')
+    body = res.read()
+    print(body)
+    eq(body, indexstring, 'default content should match index.html set content')
+    indexhtml.delete()
+    bucket.delete()
+
+
+# ---------- IndexDocument only, failures
+@attr(resource='bucket')
+@attr(method='get')
+@attr(operation='list')
+@attr(assertion='empty private buckets via s3website return a 403 for /')
+@attr('s3website')
+def test_website_private_bucket_list_empty():
+    bucket = get_new_bucket()
+    bucket.set_canned_acl('private')
+    indexname, errorname = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDoc'])
+
+    res = _website_request(bucket.name, '')
+    _website_expected_error_response(res, bucket.name, 403, 'Forbidden', 'AccessDenied')
+    bucket.delete()
+
+@attr(resource='bucket')
+@attr(method='get')
+@attr(operation='list')
+@attr(assertion='empty public buckets via s3website return a 404 for /')
+@attr('s3website')
+def test_website_public_bucket_list_empty():
+    bucket = get_new_bucket()
+    indexname, errorname = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDoc'])
+    bucket.make_public()
+
+    res = _website_request(bucket.name, '')
+    _website_expected_error_response(res, bucket.name, 404, 'Not Found', 'NoSuchKey')
+    bucket.delete()
+
+@attr(resource='bucket')
+@attr(method='get')
+@attr(operation='list')
+@attr(assertion='non-empty public buckets via s3website return page for /, where page is private')
+@attr('s3website')
+def test_website_public_bucket_list_private_index():
+    bucket = get_new_bucket()
+    indexname, errorname = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDoc'])
+    bucket.make_public()
+    indexhtml = bucket.new_key(indexname)
+    indexstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    indexhtml.set_contents_from_string(indexstring)
+    indexhtml.set_canned_acl('private')
+
+    res = _website_request(bucket.name, '')
+    _website_expected_error_response(res, bucket.name, 403, 'Forbidden', 'AccessDenied')
+    indexhtml.delete()
+    bucket.delete()
+
+@attr(resource='bucket')
+@attr(method='get')
+@attr(operation='list')
+@attr(assertion='non-empty private buckets via s3website return page for /, where page is private')
+@attr('s3website')
+def test_website_private_bucket_list_private_index():
+    bucket = get_new_bucket()
+    indexname, errorname = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDoc'])
+    bucket.set_canned_acl('private')
+    indexhtml = bucket.new_key(indexname)
+    indexstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    indexhtml.set_contents_from_string(indexstring)
+    indexhtml.set_canned_acl('private')
+
+    res = _website_request(bucket.name, '')
+    _website_expected_error_response(res, bucket.name, 403, 'Forbidden', 'AccessDenied')
+
+    indexhtml.delete()
+    bucket.delete()
+
+# ---------- IndexDocument & ErrorDocument, failures due to errordoc assigned but missing
+@attr(resource='bucket')
+@attr(method='get')
+@attr(operation='list')
+@attr(assertion='empty private buckets via s3website return a 403 for /, missing errordoc')
+@attr('s3website')
+def test_website_private_bucket_list_empty_missingerrordoc():
+    bucket = get_new_bucket()
+    indexname, errorname = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDocErrorDoc'])
+    bucket.set_canned_acl('private')
+
+    res = _website_request(bucket.name, '')
+    _website_expected_error_response(res, bucket.name, 403, 'Forbidden', 'AccessDenied')
+    body = res.read()
+    print(body)
+    
+    bucket.delete()
+
+@attr(resource='bucket')
+@attr(method='get')
+@attr(operation='list')
+@attr(assertion='empty public buckets via s3website return a 404 for /, missing errordoc')
+@attr('s3website')
+def test_website_public_bucket_list_empty_missingerrordoc():
+    bucket = get_new_bucket()
+    indexname, errorname = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDocErrorDoc'])
+    bucket.make_public()
+
+    res = _website_request(bucket.name, '')
+    _website_expected_error_response(res, bucket.name, 404, 'Not Found', 'NoSuchKey')
+    bucket.delete()
+
+@attr(resource='bucket')
+@attr(method='get')
+@attr(operation='list')
+@attr(assertion='non-empty public buckets via s3website return page for /, where page is private, missing errordoc')
+@attr('s3website')
+def test_website_public_bucket_list_private_index_missingerrordoc():
+    bucket = get_new_bucket()
+    indexname, errorname = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDocErrorDoc'])
+    bucket.make_public()
+    indexhtml = bucket.new_key(indexname)
+    indexstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    indexhtml.set_contents_from_string(indexstring)
+    indexhtml.set_canned_acl('private')
+
+    res = _website_request(bucket.name, '')
+    _website_expected_error_response(res, bucket.name, 403, 'Forbidden', 'AccessDenied')
+
+    indexhtml.delete()
+    bucket.delete()
+
+@attr(resource='bucket')
+@attr(method='get')
+@attr(operation='list')
+@attr(assertion='non-empty private buckets via s3website return page for /, where page is private, missing errordoc')
+@attr('s3website')
+def test_website_private_bucket_list_private_index_missingerrordoc():
+    bucket = get_new_bucket()
+    indexname, errorname = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDocErrorDoc'])
+    bucket.set_canned_acl('private')
+    indexhtml = bucket.new_key(indexname)
+    indexstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    indexhtml.set_contents_from_string(indexstring)
+    indexhtml.set_canned_acl('private')
+
+    res = _website_request(bucket.name, '')
+    _website_expected_error_response(res, bucket.name, 403, 'Forbidden', 'AccessDenied')
+
+    indexhtml.delete()
+    bucket.delete()
+
+# ---------- IndexDocument & ErrorDocument, failures due to errordoc assigned but not accessible
+@attr(resource='bucket')
+@attr(method='get')
+@attr(operation='list')
+@attr(assertion='empty private buckets via s3website return a 403 for /, blocked errordoc')
+@attr('s3website')
+def test_website_private_bucket_list_empty_blockederrordoc():
+    bucket = get_new_bucket()
+    indexname, errorname = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDocErrorDoc'])
+    bucket.set_canned_acl('private')
+    errorhtml = bucket.new_key(errorname)
+    errorstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    errorhtml.set_contents_from_string(errorstring)
+    errorhtml.set_canned_acl('private')
+
+    res = _website_request(bucket.name, '')
+    _website_expected_error_response(res, bucket.name, 403, 'Forbidden', 'AccessDenied')
+    body = res.read()
+    print(body)
+    ok(errorstring not in body, 'error content should match error.html set content')
+
+    errorhtml.delete()
+    bucket.delete()
+
+@attr(resource='bucket')
+@attr(method='get')
+@attr(operation='list')
+@attr(assertion='empty public buckets via s3website return a 404 for /, blocked errordoc')
+@attr('s3website')
+def test_website_public_bucket_list_empty_blockederrordoc():
+    bucket = get_new_bucket()
+    indexname, errorname = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDocErrorDoc'])
+    bucket.make_public()
+    errorhtml = bucket.new_key(errorname)
+    errorstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    errorhtml.set_contents_from_string(errorstring)
+    errorhtml.set_canned_acl('private')
+
+    res = _website_request(bucket.name, '')
+    _website_expected_error_response(res, bucket.name, 404, 'Not Found', 'NoSuchKey')
+    body = res.read()
+    print(body)
+    ok(errorstring not in body, 'error content should match error.html set content')
+
+    errorhtml.delete()
+    bucket.delete()
+
+@attr(resource='bucket')
+@attr(method='get')
+@attr(operation='list')
+@attr(assertion='non-empty public buckets via s3website return page for /, where page is private, blocked errordoc')
+@attr('s3website')
+def test_website_public_bucket_list_private_index_blockederrordoc():
+    bucket = get_new_bucket()
+    indexname, errorname = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDocErrorDoc'])
+    bucket.make_public()
+    indexhtml = bucket.new_key(indexname)
+    indexstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    indexhtml.set_contents_from_string(indexstring)
+    indexhtml.set_canned_acl('private')
+    errorhtml = bucket.new_key(errorname)
+    errorstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    errorhtml.set_contents_from_string(errorstring)
+    errorhtml.set_canned_acl('private')
+
+    res = _website_request(bucket.name, '')
+    _website_expected_error_response(res, bucket.name, 403, 'Forbidden', 'AccessDenied')
+    body = res.read()
+    print(body)
+    ok(errorstring not in body, 'error content should match error.html set content')
+
+    indexhtml.delete()
+    errorhtml.delete()
+    bucket.delete()
+
+@attr(resource='bucket')
+@attr(method='get')
+@attr(operation='list')
+@attr(assertion='non-empty private buckets via s3website return page for /, where page is private, blocked errordoc')
+@attr('s3website')
+def test_website_private_bucket_list_private_index_blockederrordoc():
+    bucket = get_new_bucket()
+    indexname, errorname = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDocErrorDoc'])
+    bucket.set_canned_acl('private')
+    indexhtml = bucket.new_key(indexname)
+    indexstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    indexhtml.set_contents_from_string(indexstring)
+    indexhtml.set_canned_acl('private')
+    errorhtml = bucket.new_key(errorname)
+    errorstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    errorhtml.set_contents_from_string(errorstring)
+    errorhtml.set_canned_acl('private')
+
+    res = _website_request(bucket.name, '')
+    _website_expected_error_response(res, bucket.name, 403, 'Forbidden', 'AccessDenied')
+    body = res.read()
+    print(body)
+    ok(errorstring not in body, 'error content should match error.html set content')
+
+    indexhtml.delete()
+    errorhtml.delete()
+    bucket.delete()
+
+# ---------- IndexDocument & ErrorDocument, failures with errordoc available
+@attr(resource='bucket')
+@attr(method='get')
+@attr(operation='list')
+@attr(assertion='empty private buckets via s3website return a 403 for /, good errordoc')
+@attr('s3website')
+def test_website_private_bucket_list_empty_gooderrordoc():
+    bucket = get_new_bucket()
+    indexname, errorname = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDocErrorDoc'])
+    bucket.set_canned_acl('private')
+    errorhtml = bucket.new_key(errorname)
+    errorstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    errorhtml.set_contents_from_string(errorstring)
+    errorhtml.set_canned_acl('public-read')
+
+    res = _website_request(bucket.name, '')
+    _website_expected_error_response(res, bucket.name, 403, 'Forbidden', 'AccessDenied')
+    body = res.read()
+    print(body)
+    eq(body, errorstring, 'error content should match error.html set content')
+
+    errorhtml.delete()
+    bucket.delete()
+
+@attr(resource='bucket')
+@attr(method='get')
+@attr(operation='list')
+@attr(assertion='empty public buckets via s3website return a 404 for /, good errordoc')
+@attr('s3website')
+def test_website_public_bucket_list_empty_gooderrordoc():
+    bucket = get_new_bucket()
+    indexname, errorname = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDocErrorDoc'])
+    bucket.make_public()
+    errorhtml = bucket.new_key(errorname)
+    errorstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    errorhtml.set_contents_from_string(errorstring)
+    errorhtml.set_canned_acl('public-read')
+
+    res = _website_request(bucket.name, '')
+    _website_expected_error_response(res, bucket.name, 404, 'Not Found', 'NoSuchKey')
+    body = res.read()
+    print(body)
+    eq(body, errorstring, 'error content should match error.html set content')
+
+    errorhtml.delete()
+    bucket.delete()
+
+@attr(resource='bucket')
+@attr(method='get')
+@attr(operation='list')
+@attr(assertion='non-empty public buckets via s3website return page for /, where page is private')
+@attr('s3website')
+def test_website_public_bucket_list_private_index_gooderrordoc():
+    bucket = get_new_bucket()
+    indexname, errorname = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDocErrorDoc'])
+    bucket.make_public()
+    indexhtml = bucket.new_key(indexname)
+    indexstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    indexhtml.set_contents_from_string(indexstring)
+    indexhtml.set_canned_acl('private')
+    errorhtml = bucket.new_key(errorname)
+    errorstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    errorhtml.set_contents_from_string(errorstring)
+    errorhtml.set_canned_acl('public-read')
+
+    res = _website_request(bucket.name, '')
+    _website_expected_error_response(res, bucket.name, 403, 'Forbidden', 'AccessDenied')
+    body = res.read()
+    print(body)
+    eq(body, errorstring, 'error content should match error.html set content')
+
+    indexhtml.delete()
+    errorhtml.delete()
+    bucket.delete()
+
+@attr(resource='bucket')
+@attr(method='get')
+@attr(operation='list')
+@attr(assertion='non-empty private buckets via s3website return page for /, where page is private')
+@attr('s3website')
+def test_website_private_bucket_list_private_index_gooderrordoc():
+    bucket = get_new_bucket()
+    indexname, errorname = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDocErrorDoc'])
+    bucket.set_canned_acl('private')
+    indexhtml = bucket.new_key(indexname)
+    indexstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    indexhtml.set_contents_from_string(indexstring)
+    indexhtml.set_canned_acl('private')
+    errorhtml = bucket.new_key(errorname)
+    errorstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    errorhtml.set_contents_from_string(errorstring)
+    errorhtml.set_canned_acl('public-read')
+
+    res = _website_request(bucket.name, '')
+    _website_expected_error_response(res, bucket.name, 403, 'Forbidden', 'AccessDenied')
+    body = res.read()
+    print(body)
+    eq(body, errorstring, 'error content should match error.html set content')
+
+    indexhtml.delete()
+    errorhtml.delete()
+    bucket.delete()

--- a/s3tests/functional/test_s3_website.py
+++ b/s3tests/functional/test_s3_website.py
@@ -114,6 +114,14 @@ def _website_expected_error_response(res, bucket_name, status, reason, code):
     ok('<li>Code: '+code+'</li>' in body, 'HTML should contain "Code: %s" ' % (code, ))
     ok(('<li>BucketName: %s</li>' % (bucket_name, )) in body, 'HTML should contain bucket name')
 
+def _website_expected_redirect_response(res, status, reason, new_url):
+    body = res.read()
+    print(body)
+    __website_expected_reponse_status(res, status, reason)
+    loc = res.getheader('Location', None)
+    eq(loc, new_url, 'Location header should be set "%s" != "%s"' % (loc,new_url,))
+    ok(len(body) == 0, 'Body of a redirect should be empty')
+
 def _website_request(bucket_name, path, method='GET'):
     url = get_website_url('http', bucket_name, path)
     print("url", url)
@@ -541,4 +549,65 @@ def test_website_private_bucket_list_private_index_gooderrordoc():
 
     indexhtml.delete()
     errorhtml.delete()
+    bucket.delete()
+
+# ------ redirect tests
+
+@attr(resource='bucket')
+@attr(method='get')
+@attr(operation='list')
+@attr(assertion='RedirectAllRequestsTo without protocol should TODO')
+@attr('s3website')
+def test_website_bucket_private_redirectall_base():
+    bucket = get_new_bucket()
+    f = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['RedirectAll'])
+    bucket.set_canned_acl('private')
+
+    res = _website_request(bucket.name, '')
+    # RGW returns "302 Found" per RFC2616
+    # S3 returns 302 Moved Temporarily per RFC1945
+    new_url = 'http://%s/' % f['RedirectAllRequestsTo_HostName']
+    _website_expected_redirect_response(res, 302, ['Found', 'Moved Temporarily'], new_url)
+
+    bucket.delete()
+
+@attr(resource='bucket')
+@attr(method='get')
+@attr(operation='list')
+@attr(assertion='RedirectAllRequestsTo without protocol should TODO')
+@attr('s3website')
+def test_website_bucket_private_redirectall_path():
+    bucket = get_new_bucket()
+    f = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['RedirectAll'])
+    bucket.set_canned_acl('private')
+
+    pathfragment = choose_bucket_prefix(template='{random}', max_len=16)
+
+    res = _website_request(bucket.name, '/'+pathfragment)
+    # RGW returns "302 Found" per RFC2616
+    # S3 returns 302 Moved Temporarily per RFC1945
+    new_url = 'http://%s/%s' % (f['RedirectAllRequestsTo_HostName'], pathfragment)
+    _website_expected_redirect_response(res, 302, ['Found', 'Moved Temporarily'], new_url)
+
+    bucket.delete()
+
+@attr(resource='bucket')
+@attr(method='get')
+@attr(operation='list')
+@attr(assertion='RedirectAllRequestsTo without protocol should TODO')
+@attr('s3website')
+def test_website_bucket_private_redirectall_path_upgrade():
+    bucket = get_new_bucket()
+    x = string.Template(WEBSITE_CONFIGS_XMLFRAG['RedirectAll+Protocol']).safe_substitute(RedirectAllRequestsTo_Protocol='https')
+    f = _test_website_prep(bucket, x)
+    bucket.set_canned_acl('private')
+
+    pathfragment = choose_bucket_prefix(template='{random}', max_len=16)
+
+    res = _website_request(bucket.name, pathfragment)
+    # RGW returns "302 Found" per RFC2616
+    # S3 returns 302 Moved Temporarily per RFC1945
+    new_url = 'https://%s/%s' % (f['RedirectAllRequestsTo_HostName'], pathfragment)
+    _website_expected_redirect_response(res, 302, ['Found', 'Moved Temporarily'], new_url)
+
     bucket.delete()

--- a/s3tests/functional/test_s3_website.py
+++ b/s3tests/functional/test_s3_website.py
@@ -20,8 +20,11 @@ from . import (
     choose_bucket_prefix,
     )
 
-from ..common import with_setup_kwargs
-from ..xmlhelper import normalize_xml_whitespace
+from ..common import ( 
+        with_setup_kwargs,
+        normalize_xml_whitespace,
+        assert_xml_equal
+)
 
 IGNORE_FIELD = 'IGNORETHIS'
 
@@ -86,6 +89,7 @@ def _test_website_prep(bucket, xml_template, hardcoded_fields = {}):
     config_xml2 = bucket.get_website_configuration_xml()
     config_xml2 = normalize_xml_whitespace(config_xml2, pretty_print=True) # For us to read
     #print("config_xml2\n", config_xml2)
+    assert_xml_equal(config_xml1, config_xml2)
     eq (config_xml1, config_xml2)
     f['WebsiteConfiguration'] = config_xml2
     return f

--- a/s3tests/functional/test_s3_website.py
+++ b/s3tests/functional/test_s3_website.py
@@ -49,7 +49,7 @@ def check_can_test_website():
             wsconf = bucket.get_website_configuration()
             CAN_WEBSITE = True
         except boto.exception.S3ResponseError as e:
-            if e.status == 404 and e.reason == 'Not Found' and e.error_code ==  'NoSuchWebsiteConfiguration':
+            if e.status == 404 and e.reason == 'Not Found' and e.error_code in ['NoSuchWebsiteConfiguration', 'NoSuchKey']:
                 CAN_WEBSITE = True
             elif e.status == 405 and e.reason == 'Method Not Allowed' and e.error_code == 'MethodNotAllowed':
                 # rgw_enable_static_website is false
@@ -132,8 +132,8 @@ def _test_website_prep(bucket, xml_template, hardcoded_fields = {}, expect_fail=
         config_xmlold = common.normalize_xml(bucket.get_website_configuration_xml(), pretty_print=True)
     except boto.exception.S3ResponseError as e:
         if str(e.status) == str(404) \
-            and True:
-            #and ('NoSuchWebsiteConfiguration' in e.body or 'NoSuchWebsiteConfiguration' in e.code):
+            and ('NoSuchWebsiteConfiguration' in e.body or 'NoSuchWebsiteConfiguration' in e.code or
+                    'NoSuchKey' in e.body or 'NoSuchKey' in e.code):
             pass
         else:
             raise e

--- a/s3tests/functional/test_s3_website.py
+++ b/s3tests/functional/test_s3_website.py
@@ -37,6 +37,8 @@ WEBSITE_CONFIGS_XMLFRAG = {
         'RedirectAll': '<RedirectAllRequestsTo><HostName>${RedirectAllRequestsTo_HostName}</HostName></RedirectAllRequestsTo>${RoutingRules}',
         'RedirectAll+Protocol': '<RedirectAllRequestsTo><HostName>${RedirectAllRequestsTo_HostName}</HostName><Protocol>${RedirectAllRequestsTo_Protocol}</Protocol></RedirectAllRequestsTo>${RoutingRules}',
         }
+INDEXDOC_TEMPLATE = '<html><h1>IndexDoc</h1><body>{random}</body></html>'
+ERRORDOC_TEMPLATE = '<html><h1>ErrorDoc</h1><body>{random}</body></html>'
 
 CAN_WEBSITE = None
 
@@ -279,7 +281,7 @@ def test_website_public_bucket_list_public_index():
     f = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDoc'])
     bucket.make_public()
     indexhtml = bucket.new_key(f['IndexDocument_Suffix'])
-    indexstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    indexstring = choose_bucket_prefix(template=INDEXDOC_TEMPLATE, max_len=256)
     indexhtml.set_contents_from_string(indexstring)
     indexhtml.make_public()
     #time.sleep(1)
@@ -305,7 +307,7 @@ def test_website_private_bucket_list_public_index():
     f = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDoc'])
     bucket.set_canned_acl('private')
     indexhtml = bucket.new_key(f['IndexDocument_Suffix'])
-    indexstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    indexstring = choose_bucket_prefix(template=INDEXDOC_TEMPLATE, max_len=256)
     indexhtml.set_contents_from_string(indexstring)
     indexhtml.make_public()
     #time.sleep(1)
@@ -365,7 +367,7 @@ def test_website_public_bucket_list_private_index():
     f = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDoc'])
     bucket.make_public()
     indexhtml = bucket.new_key(f['IndexDocument_Suffix'])
-    indexstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    indexstring = choose_bucket_prefix(template=INDEXDOC_TEMPLATE, max_len=256)
     indexhtml.set_contents_from_string(indexstring)
     indexhtml.set_canned_acl('private')
     #time.sleep(1)
@@ -390,7 +392,7 @@ def test_website_private_bucket_list_private_index():
     f = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDoc'])
     bucket.set_canned_acl('private')
     indexhtml = bucket.new_key(f['IndexDocument_Suffix'])
-    indexstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    indexstring = choose_bucket_prefix(template=INDEXDOC_TEMPLATE, max_len=256)
     indexhtml.set_contents_from_string(indexstring)
     indexhtml.set_canned_acl('private')
     ##time.sleep(1)
@@ -447,7 +449,7 @@ def test_website_public_bucket_list_private_index_missingerrordoc():
     f = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDocErrorDoc'])
     bucket.make_public()
     indexhtml = bucket.new_key(f['IndexDocument_Suffix'])
-    indexstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    indexstring = choose_bucket_prefix(template=INDEXDOC_TEMPLATE, max_len=256)
     indexhtml.set_contents_from_string(indexstring)
     indexhtml.set_canned_acl('private')
     #time.sleep(1)
@@ -471,7 +473,7 @@ def test_website_private_bucket_list_private_index_missingerrordoc():
     f = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDocErrorDoc'])
     bucket.set_canned_acl('private')
     indexhtml = bucket.new_key(f['IndexDocument_Suffix'])
-    indexstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    indexstring = choose_bucket_prefix(template=INDEXDOC_TEMPLATE, max_len=256)
     indexhtml.set_contents_from_string(indexstring)
     indexhtml.set_canned_acl('private')
     #time.sleep(1)
@@ -496,7 +498,7 @@ def test_website_private_bucket_list_empty_blockederrordoc():
     f = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDocErrorDoc'])
     bucket.set_canned_acl('private')
     errorhtml = bucket.new_key(f['ErrorDocument_Key'])
-    errorstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    errorstring = choose_bucket_prefix(template=ERRORDOC_TEMPLATE, max_len=256)
     errorhtml.set_contents_from_string(errorstring)
     errorhtml.set_canned_acl('private')
     #time.sleep(1)
@@ -523,7 +525,7 @@ def test_website_public_bucket_list_empty_blockederrordoc():
     f = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDocErrorDoc'])
     bucket.make_public()
     errorhtml = bucket.new_key(f['ErrorDocument_Key'])
-    errorstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    errorstring = choose_bucket_prefix(template=ERRORDOC_TEMPLATE, max_len=256)
     errorhtml.set_contents_from_string(errorstring)
     errorhtml.set_canned_acl('private')
     while bucket.get_key(f['ErrorDocument_Key']) is None:
@@ -549,11 +551,11 @@ def test_website_public_bucket_list_private_index_blockederrordoc():
     f = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDocErrorDoc'])
     bucket.make_public()
     indexhtml = bucket.new_key(f['IndexDocument_Suffix'])
-    indexstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    indexstring = choose_bucket_prefix(template=INDEXDOC_TEMPLATE, max_len=256)
     indexhtml.set_contents_from_string(indexstring)
     indexhtml.set_canned_acl('private')
     errorhtml = bucket.new_key(f['ErrorDocument_Key'])
-    errorstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    errorstring = choose_bucket_prefix(template=ERRORDOC_TEMPLATE, max_len=256)
     errorhtml.set_contents_from_string(errorstring)
     errorhtml.set_canned_acl('private')
     #time.sleep(1)
@@ -581,11 +583,11 @@ def test_website_private_bucket_list_private_index_blockederrordoc():
     f = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDocErrorDoc'])
     bucket.set_canned_acl('private')
     indexhtml = bucket.new_key(f['IndexDocument_Suffix'])
-    indexstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    indexstring = choose_bucket_prefix(template=INDEXDOC_TEMPLATE, max_len=256)
     indexhtml.set_contents_from_string(indexstring)
     indexhtml.set_canned_acl('private')
     errorhtml = bucket.new_key(f['ErrorDocument_Key'])
-    errorstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    errorstring = choose_bucket_prefix(template=ERRORDOC_TEMPLATE, max_len=256)
     errorhtml.set_contents_from_string(errorstring)
     errorhtml.set_canned_acl('private')
     #time.sleep(1)
@@ -614,9 +616,8 @@ def test_website_private_bucket_list_empty_gooderrordoc():
     f = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDocErrorDoc'])
     bucket.set_canned_acl('private')
     errorhtml = bucket.new_key(f['ErrorDocument_Key'])
-    errorstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
-    errorhtml.set_contents_from_string(errorstring)
-    errorhtml.set_canned_acl('public-read')
+    errorstring = choose_bucket_prefix(template=ERRORDOC_TEMPLATE, max_len=256)
+    errorhtml.set_contents_from_string(errorstring, policy='public-read')
     #time.sleep(1)
     while bucket.get_key(f['ErrorDocument_Key']) is None:
         time.sleep(SLEEP_INTERVAL)
@@ -638,7 +639,7 @@ def test_website_public_bucket_list_empty_gooderrordoc():
     f = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDocErrorDoc'])
     bucket.make_public()
     errorhtml = bucket.new_key(f['ErrorDocument_Key'])
-    errorstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    errorstring = choose_bucket_prefix(template=ERRORDOC_TEMPLATE, max_len=256)
     errorhtml.set_contents_from_string(errorstring)
     errorhtml.set_canned_acl('public-read')
    #time.sleep(1)
@@ -662,11 +663,11 @@ def test_website_public_bucket_list_private_index_gooderrordoc():
     f = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDocErrorDoc'])
     bucket.make_public()
     indexhtml = bucket.new_key(f['IndexDocument_Suffix'])
-    indexstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    indexstring = choose_bucket_prefix(template=INDEXDOC_TEMPLATE, max_len=256)
     indexhtml.set_contents_from_string(indexstring)
     indexhtml.set_canned_acl('private')
     errorhtml = bucket.new_key(f['ErrorDocument_Key'])
-    errorstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    errorstring = choose_bucket_prefix(template=ERRORDOC_TEMPLATE, max_len=256)
     errorhtml.set_contents_from_string(errorstring)
     errorhtml.set_canned_acl('public-read')
     #time.sleep(1)
@@ -691,11 +692,11 @@ def test_website_private_bucket_list_private_index_gooderrordoc():
     f = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDocErrorDoc'])
     bucket.set_canned_acl('private')
     indexhtml = bucket.new_key(f['IndexDocument_Suffix'])
-    indexstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    indexstring = choose_bucket_prefix(template=INDEXDOC_TEMPLATE, max_len=256)
     indexhtml.set_contents_from_string(indexstring)
     indexhtml.set_canned_acl('private')
     errorhtml = bucket.new_key(f['ErrorDocument_Key'])
-    errorstring = choose_bucket_prefix(template='<html><body>{random}</body></html>', max_len=256)
+    errorstring = choose_bucket_prefix(template=ERRORDOC_TEMPLATE, max_len=256)
     errorhtml.set_contents_from_string(errorstring)
     errorhtml.set_canned_acl('public-read')
     #time.sleep(1)
@@ -1010,6 +1011,10 @@ ROUTING_RULES = {
 """,
 }
 
+for k in ROUTING_RULES.keys():
+  if len(ROUTING_RULES[k]) > 0:
+    ROUTING_RULES[k] = "<!-- %s -->\n%s" % (k, ROUTING_RULES[k])
+
 ROUTING_RULES_TESTS = [
   dict(xml=dict(RoutingRules=ROUTING_RULES['empty']), url='', location=None, code=200),
   dict(xml=dict(RoutingRules=ROUTING_RULES['empty']), url='/', location=None, code=200),
@@ -1043,7 +1048,7 @@ ROUTING_RULES_TESTS = [
 
 ROUTING_ERROR_PROTOCOL = dict(code=400, reason='Bad Request', errorcode='InvalidRequest', bodyregex=r'Invalid protocol, protocol can be http or https. If not defined the protocol will be selected automatically.')
 
-ROUTING_RULES_TESTS_ERRORS = [
+ROUTING_RULES_TESTS_ERRORS = [ # TODO: Unused!
   # Invalid protocol, protocol can be http or https. If not defined the protocol will be selected automatically.
   dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=http2']), url='/', location=None, code=400, error=ROUTING_ERROR_PROTOCOL),
   dict(xml=dict(RoutingRules=ROUTING_RULES['AmazonExample1+Protocol=http2']), url='/x', location=None, code=400, error=ROUTING_ERROR_PROTOCOL),
@@ -1079,16 +1084,20 @@ def routing_setup():
   f = _test_website_prep(bucket, '')
   kwargs.update(f)
   bucket.set_canned_acl('public-read')
+  
+  k = bucket.new_key('debug-ws.xml')
+  kwargs['obj'].append(k)
+  k.set_contents_from_string('', policy='public-read')
 
   k = bucket.new_key(f['IndexDocument_Suffix'])
   kwargs['obj'].append(k)
-  s = choose_bucket_prefix(template='<html><h1>Index</h1><body>{random}</body></html>', max_len=64)
+  s = choose_bucket_prefix(template=INDEXDOC_TEMPLATE, max_len=64)
   k.set_contents_from_string(s)
   k.set_canned_acl('public-read')
 
   k = bucket.new_key(f['ErrorDocument_Key'])
   kwargs['obj'].append(k)
-  s = choose_bucket_prefix(template='<html><h1>Error</h1><body>{random}</body></html>', max_len=64)
+  s = choose_bucket_prefix(template=ERRORDOC_TEMPLATE, max_len=64)
   k.set_contents_from_string(s)
   k.set_canned_acl('public-read')
 
@@ -1112,6 +1121,10 @@ def routing_check(*args, **kwargs):
     pprint(args)
     xml_fields = kwargs.copy()
     xml_fields.update(args['xml'])
+
+    k = bucket.get_key('debug-ws.xml')
+    k.set_contents_from_string(str(args)+str(kwargs), policy='public-read')
+
     pprint(xml_fields)
     f = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDocErrorDoc'], hardcoded_fields=xml_fields)
     #print(f)


### PR DESCRIPTION
This brings in almost all of the static website testsuite. It DOES detect if the website mode is available in the RGW instance before trying those tests (and otherwise skips the tests).

Also includes some needed refactoring, and annotations of further tests that fail on AWS.

Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>