### PR TITLE
multipart copy range did not land in Jewel

### DIFF
--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -4926,7 +4926,23 @@ def _check_key_content(src, dst):
 
 @attr(resource='object')
 @attr(method='put')
-@attr(operation='check multipart copies with single small part')
+@attr(operation='check multipart copies with single small part - ranges not NotImplemented')
+@attr(assertion='fails')
+@attr('fails_on_aws')
+def test_multipart_copy_small_notimplemented():
+    (src_bucket, src_key) = _create_key_with_random_content('foo')
+    dst_bucket = get_new_bucket()
+    dst_keyname = "mymultipart"
+    size = 1
+    e = assert_raises(boto.exception.S3ResponseError, _multipart_copy, src_bucket.name, src_key.name, dst_bucket, dst_keyname, size)
+    eq(e.status, 501)
+    eq(e.error_code, u'NotImplemented')
+
+@attr(resource='object')
+@attr(method='put')
+@attr(operation='check multipart copies with single small part ')
+@attr(assertion='successful')
+@attr('fails_on_rgw')
 def test_multipart_copy_small():
     (src_bucket, src_key) = _create_key_with_random_content('foo')
     dst_bucket = get_new_bucket()
@@ -5033,6 +5049,7 @@ def test_multipart_upload_multiple_sizes():
     upload.complete_upload()
 
 @attr(assertion='successful')
+@attr('fails_on_rgw')
 def test_multipart_copy_multiple_sizes():
     (src_bucket, src_key) = _create_key_with_random_content('foo', 12 * 1024 * 1024)
     dst_bucket = get_new_bucket()


### PR DESCRIPTION
- RGW tests should trigger NotImplemented for now
- AWS tests should be work for comparision.

See note
https://github.com/ceph/s3-tests/commit/126da37dfd532fc06826d6ccf4510b9fe33e7112#commitcomment-16856581
https://github.com/ceph/s3-tests/pull/99

Signed-off-by: Robin H. Johnson <robin.johnson@dreamhost.com>