### PR TITLE
test_s3: mark test_oject_head_zero_bytes fails_on_rgw

### DIFF
--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -1012,6 +1012,7 @@ def test_multi_object_delete():
 @attr(method='put')
 @attr(operation='write zero-byte key')
 @attr(assertion='correct content length')
+@attr('fails_on_rgw')   # actually, just apache; works with civetweb.
 def test_object_head_zero_bytes():
     bucket = get_new_bucket()
     key = bucket.new_key('foo')


### PR DESCRIPTION
It works on civetweb, fails on apache.  Revert this once it is fixed.

See http://tracker.ceph.com/issues/15460

Signed-off-by: Sage Weil <sage@redhat.com>