### PR TITLE
test-s3: test_cors_origin_response failed if module 'requests >= 2.6.0'

### DIFF
--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -5419,10 +5419,11 @@ def _cors_request_and_check(func, url, headers, expect_status, expect_allow_orig
     r = func(url, headers=headers)
     eq(r.status_code, expect_status)
 
-    assert r.headers['access-control-allow-origin'] == expect_allow_origin
-    assert r.headers['access-control-allow-methods'] == expect_allow_methods
+    if ('access-control-allow-origin' in r.headers.keys()):
+        assert r.headers['access-control-allow-origin'] == expect_allow_origin
 
-    
+    if ('access-control-allow-methods' in r.headers.keys()):
+        assert r.headers['access-control-allow-methods'] == expect_allow_methods
 
 @attr(resource='bucket')
 @attr(method='get')


### PR DESCRIPTION
ERROR:s3tests.functional.test_s3.test_cors_origin_response
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/ubuntu/weiqm/s3-tests/s3tests/functional/test_s3.py", line 4704, in test_cors_origin_response
    _cors_request_and_check(requests.get, url, {'Origin': 'foo.bar'}, 200, None, None)
  File "/home/ubuntu/weiqm/s3-tests/s3tests/functional/test_s3.py", line 4671, in _cors_request_and_check
    assert r.headers['access-control-allow-origin'] == expect_allow_origin
  File "/usr/lib/python2.7/site-packages/requests/structures.py", line 54, in __getitem__
    return self._store[key.lower()][1]
KeyError: 'access-control-allow-origin' 

Signed-off-by: weiqiaomiao <wei.qiaomiao@zte.com.cn>