### PR TITLE
fix rgw_roundtrip test fail

### DIFF
--- a/s3tests/roundtrip.py
+++ b/s3tests/roundtrip.py
@@ -27,7 +27,7 @@ def writer(bucket, objname, fp, queue):
 
     start = time.time()
     try:
-        key.set_contents_from_file(fp)
+        key.set_contents_from_file(fp, rewind=True)
     except gevent.GreenletExit:
         raise
     except Exception as e:


### PR DESCRIPTION
boto no longer rewind itself in set_contents_from_file, which will trigger the assert in
realistic/RandomContentFile::seek

Signed-off-by: Tianshan Qu tianshan@xsky.com
