### PR TITLE
Complete multi-part upload during dry-run

### DIFF
--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -5922,7 +5922,7 @@ def test_multipart_resend_first_finishes_last():
         lambda: counter.inc()
         )
     mp.upload_part_from_file(fp_dryrun, 1)
-    mp.complete_upload
+    mp.complete_upload()
 
     bucket.delete_key(key_name)
 


### PR DESCRIPTION
While it may be valuable to verify that deleting a non-existent key is OK, that doesn't seem to be the point of this test.