### PR TITLE
Use non-broken version of setuptools, and fix bootstrap to be more po…

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -12,9 +12,18 @@ if [ -f /etc/debian_version ]; then
         echo "$0: missing required DEB packages. Installing via sudo." 1>&2
         sudo apt-get -y install $missing
     fi
-fi
-if [ -f /etc/redhat-release ]; then
-    for package in python-pip python-virtualenv python-devel libevent-devel; do
+elif [ -f /etc/fedora-release ]; then
+    for package in python-pip python2-virtualenv python-devel libevent-devel; do
+        if [ "$(rpm -qa $package 2>/dev/null)" == "" ]; then
+            missing="${missing:+$missing }$package"
+        fi
+    done
+    if [ -n "$missing" ]; then
+        echo "$0: missing required RPM packages. Installing via sudo." 1>&2
+        sudo yum -y install $missing
+    fi
+elif [ -f /etc/redhat-release ]; then
+    for package in python2-pip python-virtualenv python-devel libevent-devel; do
         if [ "$(rpm -qa $package 2>/dev/null)" == "" ]; then
             missing="${missing:+$missing }$package"
         fi
@@ -30,8 +39,8 @@ virtualenv --no-site-packages --distribute virtualenv
 # avoid pip bugs
 ./virtualenv/bin/pip install --upgrade pip
 
-# work-around change in pip 1.5
-./virtualenv/bin/pip install setuptools --no-use-wheel --upgrade
+# slightly old version of setuptools; newer fails w/ requests 0.14.0
+./virtualenv/bin/pip install setuptools==32.3.1
 
 ./virtualenv/bin/pip install -r requirements.txt
 


### PR DESCRIPTION
…rtable.

Most recent version of setuptools breaks when asked to load requests 0.14.0.
symptom, complains about not being able to import filterfalse thus:
        from six.moves import map, filter, filterfalse
this comes from setuptools, and older versions of setuptools don't have
this problem.

Various versions of centos7 and fedora have interesting names for packages,
	centos7: python-pip is python2-pip
	fedora24: python-virtualenv is python2-virtualenv
This is somewhat masked by using sudo yum: if the actual package
is installed, rpm knows that the capability is there and does nothing.
But, if the package isn't there, or you haven't chosen to set up
sudo to work that way, this does not work.

Signed-off-by: Marcus Watts <mwatts@redhat.com>
(cherry picked from commit ddc150439d9dc1fe1edca6891820401ee00fa2ae)