### PR TITLE
Use latest requests.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ bunch >=1.0.0
 # 0.14 switches to libev, that means bootstrap needs to change too
 gevent >=1.0
 isodate >=0.4.4
-requests ==0.14.0
+requests
 pytz >=2011k
 ordereddict
 httplib2

--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -5695,8 +5695,8 @@ def _cors_request_and_check(func, url, headers, expect_status, expect_allow_orig
     r = func(url, headers=headers)
     eq(r.status_code, expect_status)
 
-    assert r.headers['access-control-allow-origin'] == expect_allow_origin
-    assert r.headers['access-control-allow-methods'] == expect_allow_methods
+    assert r.headers.get('access-control-allow-origin') == expect_allow_origin
+    assert r.headers.get('access-control-allow-methods') == expect_allow_methods
 
     
 


### PR DESCRIPTION
The latest requests was almost compatible with s3-tests, except
for s3tests.functional.test_s3:test_cors_origin_response
which blows up with a KeyValue error.  This fixes the KeyValue
error and allows any version of requests to be used.

Signed-off-by: Marcus Watts <mwatts@redhat.com>