### PR TITLE
clear key.version_id now that GET requests return x-amz-version-id header

### DIFF
--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -6808,6 +6808,8 @@ def test_versioning_obj_plain_null_version_overwrite():
     key.set_contents_from_string(content2)
 
     eq(key.get_contents_as_string(), content2)
+    # get_contents_to_string() will set key.version_id, clear it
+    key.version_id = None
 
     version_id = None
     for k in bucket.list_versions():


### PR DESCRIPTION
https://github.com/ceph/ceph/pull/14117 added the `x-amz-version-id` header to GetObj requests. boto's [Key.get_contents_as_string()](http://boto.cloudhackers.com/en/latest/ref/s3.html#boto.s3.key.Key.get_contents_as_string) will set `Key.version_id` based on this header. this is causing `test_versioning_obj_plain_null_version_overwrite()` to issue a `get_contents_as_string()` against the version_id it had just deleted, failing with `S3ResponseError: 404 Not Found`