### PR TITLE
modify the thread sleep time in lifecycle expiration test so that it can pass on ceph master branch.

### DIFF
--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -7499,13 +7499,13 @@ def test_lifecycle_expiration():
     # Get list of all keys
     init_keys = bucket.get_all_keys()
     # Wait for first expiration (plus fudge to handle the timer window)
-    time.sleep(35)
+    time.sleep(6)
     expire1_keys = bucket.get_all_keys()
     # Wait for next expiration cycle
-    time.sleep(15)
+    time.sleep(2)
     keep2_keys = bucket.get_all_keys()
     # Wait for final expiration cycle
-    time.sleep(25)
+    time.sleep(8)
     expire3_keys = bucket.get_all_keys()
 
     eq(len(init_keys), 6)


### PR DESCRIPTION
Because https://github.com/ceph/ceph/pull/15677 fixes the bug and lifecycle doesn't process the bucket which has been deleted now. The sleep time should be lower in lifecycle expiration so that the test case can pass(lc interval is still 2 seconds).

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>