### PR TITLE
Fix CORS tests without Origin headers

### DIFF
--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -5760,8 +5760,8 @@ def _cors_request_and_check(func, url, headers, expect_status, expect_allow_orig
     r = func(url, headers=headers)
     eq(r.status_code, expect_status)
 
-    assert r.headers['access-control-allow-origin'] == expect_allow_origin
-    assert r.headers['access-control-allow-methods'] == expect_allow_methods
+    assert r.headers.get('access-control-allow-origin', None) == expect_allow_origin
+    assert r.headers.get('access-control-allow-methods', None) == expect_allow_methods
 
     
 


### PR DESCRIPTION
According to the CORS spec 6.1.1 [1] requests without an Origin header
should not return any access-control-* headers. But the current test
method expects these headers to be always present in the response. Fix
this by defaulting to None if the header is not present.

[1] https://www.w3.org/TR/cors/#resource-requests