### PR TITLE
Care less about ordering when checking grants

### DIFF
--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -81,8 +81,8 @@ def check_grants(got, want):
     in any order.
     """
     eq(len(got), len(want))
-    got = sorted(got, key=operator.attrgetter('id'))
-    want = sorted(want, key=operator.itemgetter('id'))
+    got = sorted(got, key=operator.attrgetter('id', 'permission'))
+    want = sorted(want, key=operator.itemgetter('id', 'permission'))
     for g, w in zip(got, want):
         w = dict(w)
         eq(g.permission, w.pop('permission'))


### PR DESCRIPTION
Some tests, like test_object_header_acl_grants and test_bucket_header_acl_grants, use the same id for all permissions. `sort()` is stable, so those tests end up testing the order of acl grants returned by Boto. Not sure, but I think this may in turn depend on the order of HTTP headers, where the order is not significant.