### PR TITLE
test bucket policy with conditionals 

### DIFF
--- a/s3tests/functional/policy.py
+++ b/s3tests/functional/policy.py
@@ -1,0 +1,38 @@
+import json
+
+class Statement(object):
+    def __init__(self, action, resource, principal = {"AWS" : "*"}, effect= "Allow", condition = None):
+        self.principal = principal
+        self.action = action
+        self.resource = resource
+        self.condition = condition
+        self.effect = effect
+
+    def to_dict(self):
+        d = { "Action" : self.action,
+              "Principal" : self.principal,
+              "Effect" : self.effect,
+              "Resource" : self.resource
+        }
+
+        if self.condition is not None:
+            d["Condition"] = self.condition
+
+        return d
+
+class Policy(object):
+    def __init__(self):
+        self.statements = []
+
+    def add_statement(self, s):
+        self.statements.append(s)
+        return self
+
+    def to_json(self):
+        policy_dict = {
+            "Version" : "2012-10-17",
+            "Statement":
+            [s.to_dict() for s in self.statements]
+        }
+
+        return json.dumps(policy_dict)

--- a/s3tests/functional/policy.py
+++ b/s3tests/functional/policy.py
@@ -36,3 +36,11 @@ class Policy(object):
         }
 
         return json.dumps(policy_dict)
+
+def make_json_policy(action, resource, principal={"AWS": "*"}, conditions=None):
+    """
+    Helper function to make single statement policies
+    """
+    s = Statement(action, resource, principal, condition=conditions)
+    p = Policy()
+    return p.add_statement(s).to_json()

--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -44,7 +44,7 @@ from .utils import assert_raises
 from .utils import generate_random
 from .utils import region_sync_meta
 
-from .policy import Policy, Statement
+from .policy import Policy, Statement, make_json_policy
 
 import AnonymousAuth
 
@@ -8743,28 +8743,6 @@ def test_sse_kms_read_declare():
 
 def _make_arn_resource(path="*"):
     return "arn:aws:s3:::{}".format(path)
-
-def make_json_policy(action, resource, principal={"AWS": "*"}, conditions=None):
-
-    policy = {
-        "Version": "2012-10-17",
-        "Statement": [{
-            "Effect": "Allow",
-            "Principal": principal,
-            "Action": action,
-            "Resource": [
-                resource
-            ],
-        }]
-    }
-
-    # Currently lets only support adding a common conditional to every
-    # statement in this function
-    for statement in policy["Statement"]:
-        if conditions is not None:
-            statement["Condition"] = conditions
-
-    return json.dumps(policy)
 
 @attr(resource='bucket')
 @attr(method='get')

--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -9346,6 +9346,7 @@ def test_put_tags_acl_public():
 @attr(operation='Test DeleteObjTagging public')
 @attr(assertion='success')
 @attr('tagging')
+@attr('bucket-policy')
 def test_delete_tags_obj_public():
     bucket, key = _create_key_with_random_content('testputtagsacl')
 

--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -8737,6 +8737,28 @@ def test_sse_kms_read_declare():
     e = assert_raises(boto.exception.S3ResponseError, key.get_contents_as_string, headers=sse_kms_client_headers)
     eq(e.status, 400)
 
+def _make_arn_resource(path="*"):
+    return "arn:aws:s3:::{}".format(path)
+
+def make_json_policy(action, resource, principal={"AWS": "*"}, conditions=None):
+
+    policy = {
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Allow",
+            "Principal": principal,
+            "Action": action,
+            "Resource": [
+                resource
+            ],
+        }]
+    }
+
+    if conditions is not None:
+        policy["Statement"]["Condition"] = conditions
+
+    return json.dumps(policy)
+
 @attr(resource='bucket')
 @attr(method='get')
 @attr(operation='Test Bucket Policy')
@@ -9273,28 +9295,13 @@ def test_put_obj_with_tags():
     res_tagset = _get_obj_tags(bucket, key.name)
     eq(input_tagset.to_dict(), res_tagset.to_dict())
 
-def _make_arn_resource(path="*"):
-    return "arn:aws:s3:::{}".format(path)
-
-def make_json_policy(action, resource, principal={"AWS": "*"}):
-    return json.dumps(
-    {
-        "Version": "2012-10-17",
-        "Statement": [{
-        "Effect": "Allow",
-        "Principal": principal,
-        "Action": action,
-        "Resource": [
-            resource
-          ]
-        }]
-    })
 
 @attr(resource='object')
 @attr(method='get')
 @attr(operation='Test GetObjTagging public read')
 @attr(assertion='success')
 @attr('tagging')
+@attr('bucket-policy')
 def test_get_tags_acl_public():
     bucket, key = _create_key_with_random_content('testputtagsacl')
 
@@ -9315,6 +9322,7 @@ def test_get_tags_acl_public():
 @attr(operation='Test PutObjTagging public wrote')
 @attr(assertion='success')
 @attr('tagging')
+@attr('bucket-policy')
 def test_put_tags_acl_public():
     bucket, key = _create_key_with_random_content('testputtagsacl')
 

--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -8754,8 +8754,11 @@ def make_json_policy(action, resource, principal={"AWS": "*"}, conditions=None):
         }]
     }
 
-    if conditions is not None:
-        policy["Statement"]["Condition"] = conditions
+    # Currently lets only support adding a common conditional to every
+    # statement in this function
+    for statement in policy["Statement"]:
+        if conditions is not None:
+            statement["Condition"] = conditions
 
     return json.dumps(policy)
 

--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -8970,14 +8970,14 @@ def test_bucket_policy_set_condition_operator_end_with_IfExists():
 @attr('bucket-policy')
 def test_bucket_policy_list_bucket_with_prefix():
     bucket = _create_keys(keys=['foo','folder/foo1','folder/foo2','folder/foo3','foo2'])
-    tag_conditional = {"StringEquals": {
+    conditional = {"StringEquals": {
         "s3:prefix" : "folder"
     }}
 
     resource = _make_arn_resource(bucket.name)
-    policy_document = make_json_policy("s3:ListBucket",
-                                       resource,
-                                       conditions=tag_conditional)
+    p = Policy()
+    s = Statement("s3:ListBucket", resource, condition=conditional)
+    policy_document = p.add_statement(s).to_json()
 
     eq(bucket.set_policy(policy_document), True)
 

--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -9479,3 +9479,59 @@ def test_bucket_policy_get_obj_existing_tag():
 
     res = new_conn.make_request("GET",bucket.name, 'invalidtag')
     eq(res.status, 403)
+
+@attr(resource='object')
+@attr(method='get')
+@attr(operation='Test ExistingObjectTag conditional on get object tagging')
+@attr(assertion='success')
+@attr('tagging')
+@attr('bucket-policy')
+def test_bucket_policy_get_obj_tagging_existing_tag():
+
+    bucket = _create_keys(keys=['publictag','privatetag','invalidtag'])
+
+
+    tag_conditional = {"StringEquals": {
+        "s3:ExistingObjectTag/security" : "public"
+    }}
+
+    resource = _make_arn_resource("{}/{}".format(bucket.name, "*"))
+    policy_document = make_json_policy("s3:GetObjectTagging",
+                                       resource,
+                                       conditions=tag_conditional)
+
+    bucket.set_policy(policy_document)
+    input_tagset = S3TestTagSet()
+    input_tagset.add_tag('security','public')
+    input_tagset.add_tag('foo','bar')
+
+    input_tagset2 = S3TestTagSet()
+    input_tagset2.add_tag('security','private')
+
+    input_tagset3 = S3TestTagSet()
+    input_tagset3.add_tag('security1','public')
+
+    res = _put_obj_tags(bucket, 'publictag', input_tagset.to_xml())
+    eq(res.status, 200)
+
+    res = _put_obj_tags(bucket, 'privatetag', input_tagset2.to_xml())
+    eq(res.status, 200)
+
+    res = _put_obj_tags(bucket, 'invalidtag', input_tagset3.to_xml())
+    eq(res.status, 200)
+
+    new_conn = _get_alt_connection()
+    res = new_conn.make_request("GET",bucket.name, 'publictag', query_args='tagging')
+    eq(res.status, 200)
+
+    # A get object itself should fail since we allowed only GetObjectTagging
+    res = new_conn.make_request("GET",bucket.name, 'publictag')
+    eq(res.status, 403)
+
+    res = new_conn.make_request("GET",bucket.name, 'privatetag', query_args='tagging')
+    eq(res.status, 403)
+
+    res = new_conn.make_request("GET",bucket.name, 'invalidtag', query_args='tagging')
+    eq(res.status, 403)
+
+

--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -9890,7 +9890,7 @@ def test_bucket_policy_put_obj_acl():
     p = Policy()
     resource = _make_arn_resource("{}/{}".format(bucket.name, "*"))
     s1 = Statement("s3:PutObject",resource)
-    s2 = Statement("s3:PutOBject", resource, effect="Deny", condition=conditional)
+    s2 = Statement("s3:PutObject", resource, effect="Deny", condition=conditional)
 
     policy_document = p.add_statement(s1).add_statement(s2).to_json()
 

--- a/s3tests/functional/utils.py
+++ b/s3tests/functional/utils.py
@@ -52,3 +52,12 @@ def region_sync_meta(targets, region):
         if conf.sync_meta_wait:
             time.sleep(conf.sync_meta_wait)
 
+
+def get_grantee(policy, permission):
+    '''
+    Given an object/bucket policy, extract the grantee with the required permission
+    '''
+
+    for g in policy.acl.grants:
+        if g.permission == permission:
+            return g.id


### PR DESCRIPTION
Adding tests for bucket policies with conditionals
Tests added so far:
- Get Object (with ExistingObjectTag)
- Put Object Tagging
- Get Object Tagging 
- Put Object
- Put Object ACL
- Get Object ACL

- CreateBucket
- ListBucket (with prefix/max-keys/delimiter conditionals)
