### PR TITLE
Fix a typos for lifecycle test case

### DIFF
--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -7798,7 +7798,6 @@ def test_lifecycle_set_noncurrent():
     eq(res.reason, 'OK')
 
 
-# The test harnass for lifecycle is configured to treat days as 2 second intervals.
 @attr(resource='bucket')
 @attr(method='put')
 @attr(operation='test lifecycle non-current version expiration')
@@ -7883,7 +7882,6 @@ def test_lifecycle_set_empty_filter():
 
 
 
-# The test harnass for lifecycle is configured to treat days as 1 second intervals.
 @attr(resource='bucket')
 @attr(method='put')
 @attr(operation='test lifecycle delete marker expiration')
@@ -7936,7 +7934,6 @@ def test_lifecycle_set_multipart():
     eq(res.reason, 'OK')
 
 
-# The test harnass for lifecycle is configured to treat days as 1 second intervals.
 @attr(resource='bucket')
 @attr(method='put')
 @attr(operation='test lifecycle multipart expiration')

--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -7588,7 +7588,7 @@ def test_lifecycle_get_no_id():
             assert False
 
 
-# The test harnass for lifecycle is configured to treat days as 2 second intervals.
+# The test harness for lifecycle is configured to treat days as 10 second intervals.
 @attr(resource='bucket')
 @attr(method='put')
 @attr(operation='test lifecycle expiration')


### PR DESCRIPTION
1. According to the commit 9204283def8e0bcfe14a57f0c87ed20735214f53,
lc debug interval should be set to 10s.

2. Cleanup some unneeded comments.

Signed-off-by: Enming Zhang <enming.zhang@umcloud.com>