### PR TITLE
Removing error_code check for some tests

### DIFF
--- a/s3tests/functional/test_headers.py
+++ b/s3tests/functional/test_headers.py
@@ -314,7 +314,6 @@ def test_object_create_bad_contentlength_empty():
     e = assert_raises(boto.exception.S3ResponseError, key.set_contents_from_string, 'bar')
     eq(e.status, 400)
     eq(e.reason.lower(), 'bad request') # some proxies vary the case
-    eq(e.error_code, None)
 
 
 @tag('auth_common')
@@ -361,7 +360,6 @@ def test_object_create_bad_contentlength_unreadable():
     e = assert_raises(boto.exception.S3ResponseError, key.set_contents_from_string, 'bar')
     eq(e.status, 400)
     eq(e.reason.lower(), 'bad request') # some proxies vary the case
-    eq(e.error_code, None)
 
 
 @tag('auth_common')
@@ -658,7 +656,6 @@ def test_bucket_create_bad_contentlength_unreadable():
     e = assert_raises(boto.exception.S3ResponseError, get_new_bucket)
     eq(e.status, 400)
     eq(e.reason.lower(), 'bad request') # some proxies vary the case
-    eq(e.error_code, None)
 
 
 # the teardown is really messed up here. check it out


### PR DESCRIPTION
Removing unneeded error_code checks form some tests
(https://github.com/ceph/s3-tests/issues/6)