### PR TITLE
Add test for muiltpart copy without 'x-amz-copy-source-range' header

### DIFF
--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -5399,6 +5399,25 @@ def test_multipart_copy_invalid_range():
 
 @attr(resource='object')
 @attr(method='put')
+@attr(operation='check multipart copies without x-amz-copy-source-range')
+def test_multipart_copy_without_range():
+    (src_bucket, src_key) = _create_key_with_random_content('source', size=10)
+    dst_bucket = get_new_bucket()
+    dst_keyname = "mymultipartcopy"
+
+    upload = dst_bucket.initiate_multipart_upload(dst_keyname)
+    # MultiPartUpload.copy_part_from_key() always add "x-amz-copy-source-range" in header
+    # So we can use copy_key() with query_args
+    query_args = 'uploadId=%s&partNumber=%d' % (upload.id, 1)
+    dst_bucket.copy_key(dst_keyname, src_bucket.name, src_key.name, query_args=query_args)
+    upload.complete_upload()
+
+    key2 = dst_bucket.get_key(dst_keyname)
+    eq(key2.size, 10)
+    _check_key_content(src_key, key2)
+
+@attr(resource='object')
+@attr(method='put')
 @attr(operation='check multipart copies with single small part')
 def test_multipart_copy_special_names():
     src_bucket = get_new_bucket()


### PR DESCRIPTION
This pr is prepared for https://github.com/ceph/ceph/pull/20002.