### PR TITLE
Remove pin to old setuptools version 32.3.1

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -39,9 +39,6 @@ virtualenv --no-site-packages --distribute virtualenv
 # avoid pip bugs
 ./virtualenv/bin/pip install --upgrade pip
 
-# slightly old version of setuptools; newer fails w/ requests 0.14.0
-./virtualenv/bin/pip install setuptools==32.3.1
-
 ./virtualenv/bin/pip install -r requirements.txt
 
 # forbid setuptools from using the network because it'll try to use


### PR DESCRIPTION
A comment said newer versions of setuptools ran into problems with requests version 0.14.0, but there are 67 newer releases of requests now, surely that failure was fixed by now.