### PR TITLE
Content-MD5 check test for s3:PutObjectTagging and add tag related permission

### DIFF
--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -9562,6 +9562,11 @@ def test_get_tags_acl_public():
 def test_put_tags_acl_public():
     bucket, key = _create_key_with_random_content('testputtagsacl')
 
+    new_conn = _get_alt_connection()
+    input_tagset = _create_simple_tagset(10)
+    res = _put_obj_tags_conn(new_conn, bucket.name, key.name, input_tagset.to_xml())
+    eq(res.status, 403)
+
     resource = _make_arn_resource("{}/{}".format(bucket.name, key.name))
     #principal = {"AWS": "s3test2"} This needs a tenanted user?
     policy_document = make_json_policy("s3:PutObjectTagging",

--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -10090,7 +10090,8 @@ def test_bucket_policy_put_obj_request_obj_tag():
     resource = _make_arn_resource("{}/{}".format(bucket.name, "*"))
 
     s1 = Statement("s3:PutObject", resource, effect="Allow", condition=tag_conditional)
-    policy_document = p.add_statement(s1).to_json()
+    s2 = Statement("s3:PutObjectTagging", resource, effect="Allow")
+    policy_document = p.add_statement(s1).add_statement(s2).to_json()
 
     bucket.set_policy(policy_document)
 


### PR DESCRIPTION
This PR is prepared for [ceph/ceph#21486](https://github.com/ceph/ceph/pull/21486)

