### PR TITLE
Fix some dependencies in s3tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,5 @@ gevent >=1.0
 isodate >=0.4.4
 requests >=2.10.0
 pytz >=2011k
-ordereddict
 httplib2
 lxml

--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -49,7 +49,7 @@ from .policy import Policy, Statement, make_json_policy
 import AnonymousAuth
 
 from email.header import decode_header
-from ordereddict import OrderedDict
+from collections import OrderedDict
 
 from boto.s3.cors import CORSConfiguration
 from urllib import quote_plus


### PR DESCRIPTION
1. Update minimum requests version to 2.10.0
2. Remove dependency of the old ordereddict and use default collections.OrderedDict