### PR TITLE
Force python2 virtualenv

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -34,7 +34,7 @@ elif [ -f /etc/redhat-release ]; then
     fi
 fi
 
-virtualenv --no-site-packages --distribute virtualenv
+virtualenv -p python2 --no-site-packages --distribute virtualenv
 
 # avoid pip bugs
 ./virtualenv/bin/pip install --upgrade pip


### PR DESCRIPTION
python defaults to 2.7 on Fedora 29 yet virtualenv chooses 3.7
instead.  Force python2 to work around this.