### PR TITLE
Update outdated bucket naming tests

### DIFF
--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -3276,27 +3276,6 @@ def test_bucket_create_naming_bad_long_254():
 def test_bucket_create_naming_bad_long_255():
     _test_bucket_create_naming_bad_long(255)
 
-'''
-# Breaks DNS with SubdomainCallingFormat
-@attr('fails_with_subdomain')
-@attr(resource='bucket')
-@attr(method='get')
-@attr(operation='list w/251 byte name')
-@attr(assertion='fails with subdomain')
-@attr('fails_on_aws') # <Error><Code>InvalidBucketName</Code><Message>The specified bucket is not valid.</Message>...</Error>
-def test_bucket_list_long_name():
-    prefix = get_new_bucket_name()
-    length = 251
-    num = length - len(prefix)
-    bucket = get_new_bucket(targets.main.default, '{prefix}{name}'.format(
-            prefix=prefix,
-            name=num*'a',
-            ))
-    got = bucket.list()
-    got = list(got)
-    eq(got, [])
-'''
-
 
 # AWS does not enforce all documented bucket restrictions.
 # http://docs.amazonwebservices.com/AmazonS3/2006-03-01/dev/index.html?BucketRestrictions.html


### PR DESCRIPTION
It seems like 'fails_on_aws' was intended to mark cases when AWS didn't enforce their own documentation, but when these tests began to fail when AWS changed the bucket naming rules to enforce DNS-compliance, it seems like they were marked as 'fails_on_aws' instead of properly changing the tests.

The bucket name enforcement rules in us-east-1 were updated to match those for other regions (as of March 2018), making these tests now over a half-year out of date for all regions.