### PR TITLE
nuke_prefixed_buckets() ignores 404 from bucket delete

### DIFF
--- a/s3tests/functional/__init__.py
+++ b/s3tests/functional/__init__.py
@@ -91,7 +91,13 @@ def nuke_prefixed_buckets_on_conn(prefix, name, conn):
                             ))
                         # key.set_canned_acl('private')
                         bucket.delete_key(key.name, version_id = key.version_id)
-                    bucket.delete()
+                    try:
+                        bucket.delete()
+                    except boto.exception.S3ResponseError as e:
+                        # if DELETE times out, the retry may see NoSuchBucket
+                        if e.error_code != 'NoSuchBucket':
+                            raise e
+                        pass
                     success = True
                 except boto.exception.S3ResponseError as e:
                     if e.error_code != 'AccessDenied':


### PR DESCRIPTION
if a bucket delete request times out, the retry will likely get a 404 NoSuchBucket response. ignore that error and treat this as a success

this showed up as a failure in http://qa-proxy.ceph.com/teuthology/yuriw-2019-04-17_22:56:53-rgw-nautilus-distro-basic-smithi/3859872/teuthology.log
```
S3ResponseError: S3ResponseError: 404 Not Found
<?xml version="1.0" encoding="UTF-8"?><Error><Code>NoSuchBucket</Code><BucketName>test-client.0-vkgr2clo531930f-92</BucketName><RequestId>tx000000000000000001818-005cb9a0bb-11f8-default</RequestId><HostId>11f8-default-default</HostId></Error>
```
where the boto log shows a retry on the final DELETE request:
```
boto: DEBUG: encountered SSLError exception, reconnecting
boto: DEBUG: establishing HTTPS connection: host=example.com, kwargs={'port': 7281, 'timeout': 30}
```