### PR TITLE
make sure that virtualenv is python2 regardless of host

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -34,7 +34,7 @@ elif [ -f /etc/redhat-release ]; then
     fi
 fi
 
-virtualenv --no-site-packages --distribute virtualenv
+virtualenv --python=$(which python2) --no-site-packages --distribute virtualenv
 
 # avoid pip bugs
 ./virtualenv/bin/pip install --upgrade pip


### PR DESCRIPTION
when running on fedora29 the virtualenv was python3. this didn't work since the tests are pyhton2.

Signed-off-by: Yuval Lifshitz <yuvalif@yahoo.com>