### PR TITLE
rgw: az: Add archive zone test cases

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,3 +54,21 @@ You can run only the boto3 tests with::
 
         S3TEST_CONF=your.conf ./virtualenv/bin/nosetests -v -s -A 'not fails_on_rgw' s3tests_boto3.functional
 
+If you also want to run the archive sync module test cases, included as part of
+the boto3 tests, one configuration with two zones is required. One of the those
+zones will be the archive zone (az). You can set up this configuration
+following the documentation available at:
+
+http://docs.ceph.com/docs/nautilus/radosgw/archive-sync-module/
+
+With the archive sync module enabled, you need to configure 'host_az' and
+'port_az' in your s3test conf (see s3tests.conf.SAMPLE) together with
+RGW_S3_USE_AZ=1 in the environment. Use 'host' and 'port' to configure the non
+archive zone.
+
+If RGW_S3_USE_AZ is not available in the environment the test cases will be
+skipped. It is the default behaviour.
+
+To run the archive zone test cases directly:
+
+        RGW_S3_USE_AZ=1 S3TEST_CONF=your.conf ./virtualenv/bin/nosetests -v -a 'archive-zone' s3tests_boto3.functional

--- a/s3tests.conf.SAMPLE
+++ b/s3tests.conf.SAMPLE
@@ -10,6 +10,10 @@ port = 8000
 ## say "False" to disable TLS
 is_secure = False
 
+# RGW/S3 archive zone
+host_az = localhost
+port_az = 8000
+
 [fixtures]
 ## all the buckets created will start with this prefix;
 ## {random} will be filled with random characters to pad

--- a/s3tests_boto3/functional/__init__.py
+++ b/s3tests_boto3/functional/__init__.py
@@ -161,11 +161,14 @@ def setup():
 
     # vars from the DEFAULT section
     config.default_host = defaults.get("host")
+    config.default_host_az = defaults.get("host_az")
     config.default_port = int(defaults.get("port"))
+    config.default_port_az = int(defaults.get("port_az"))
     config.default_is_secure = cfg.getboolean('DEFAULT', "is_secure")
 
     proto = 'https' if config.default_is_secure else 'http'
     config.default_endpoint = "%s://%s:%d" % (proto, config.default_host, config.default_port)
+    config.default_endpoint_az = "%s://%s:%d" % (proto, config.default_host_az, config.default_port_az)
 
     # vars from the main section
     config.main_access_key = cfg.get('s3 main',"access_key")
@@ -278,6 +281,18 @@ def get_bad_auth_client(aws_access_key_id='badauth'):
                         endpoint_url=config.default_endpoint,
                         use_ssl=config.default_is_secure,
                         config=Config(signature_version='s3v4'))
+    return client
+
+def get_az_client(client_config=None):
+    if client_config == None:
+        client_config = Config(signature_version='s3v4')
+
+    client = boto3.client(service_name='s3',
+                        aws_access_key_id=config.main_access_key,
+                        aws_secret_access_key=config.main_secret_key,
+                        endpoint_url=config.default_endpoint_az,
+                        use_ssl=config.default_is_secure,
+                        config=client_config)
     return client
 
 bucket_counter = itertools.count(1)


### PR DESCRIPTION
Test cases for the archive sync module feature. It requires to set up
one configuration with two available zones. One of those zones is the
archive zone (az):

http://docs.ceph.com/docs/nautilus/radosgw/archive-sync-module/

To run the test cases you need to configure 'host_az' and 'port_az' in
your s3test conf (see s3tests.conf.SAMPLE) and set up RGW_S3_USE_AZ=1 in
the environment. Use 'host' and 'port' to configure the non archive
zone.

If RGW_S3_USE_AZ is not available in the environment the test cases will
be skipped. It is the default behaviour.

To run the archive zone test cases directly:

$ RGW_S3_USE_AZ=1 S3TEST_CONF=./s3tests.conf \
./virtualenv/bin/nosetests -v -a 'archive-zone' s3tests_boto3.functional

Signed-off-by: Javier M. Mellid <jmunhoz@igalia.com>