### PR TITLE
boto2: tag more tests with fails_with_subdomain

### DIFF
--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -155,6 +155,7 @@ def test_versioning_obj_read_not_exist_null():
 @attr(operation='append object')
 @attr(assertion='success')
 @attr('fails_on_aws')
+@attr('fails_with_subdomain')
 @attr('appendobject')
 def test_append_object():
     bucket = get_new_bucket()
@@ -178,6 +179,7 @@ def test_append_object():
 @attr(operation='append to normal object')
 @attr(assertion='fails 409')
 @attr('fails_on_aws')
+@attr('fails_with_subdomain')
 @attr('appendobject')
 def test_append_normal_object():
     bucket = get_new_bucket()
@@ -197,6 +199,7 @@ def test_append_normal_object():
 @attr(operation='append position not right')
 @attr(assertion='fails 409')
 @attr('fails_on_aws')
+@attr('fails_with_subdomain')
 @attr('appendobject')
 def test_append_object_position_wrong():
     bucket = get_new_bucket()
@@ -953,6 +956,7 @@ def test_encryption_sse_c_multipart_invalid_chunks_2():
 @attr(method='get')
 @attr(operation='Test Bucket Policy for a user belonging to a different tenant')
 @attr(assertion='succeeds')
+@attr('fails_with_subdomain')
 @attr('bucket-policy')
 def test_bucket_policy_different_tenant():
     bucket = get_new_bucket()


### PR DESCRIPTION
test_bucket_policy_different_tenant fails because it adds a : to the beginning of the hostname, ie:
> Host: :test-client.0-oktbnrjh6qacop7-25.s3.smithi003.front.sepia.ceph.com

the append tests fail with 403 Forbidden because they use `key.generate_url()` on a connection with calling_format=subdomain, but send the raw request to the unmodified hostname. because the Host header doesn't match the signature of the presigned url, the signature validation fails