### PR TITLE
test_put_obj_with_tags 

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -10869,7 +10869,7 @@ def test_put_obj_with_tags():
     eq(body, data)
 
     response = client.get_object_tagging(Bucket=bucket_name, Key=key)
-    eq(response['TagSet'], tagset)
+    eq(response['TagSet'].sort(), tagset.sort())
 
 def _make_arn_resource(path="*"):
     return "arn:aws:s3:::{}".format(path)


### PR DESCRIPTION
**According to ISSUE #317 :** 
The ceph test "test_put_obj_with_tags" contains the check:
eq(response['TagSet'], tagset).
it fails because of tagging order, but AWS spec does not specifies which order the tags supposed to return.

**CHANGES:**
1. sort both lists.

**FIXES**:
1. ISSUE #317