### PR TITLE
Fix test_bucket_list_prefix_unreadable

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -1,4 +1,5 @@
 import boto3
+import botocore.handlers
 import botocore.session
 from botocore.exceptions import ClientError
 from botocore.exceptions import ParamValidationError
@@ -927,6 +928,12 @@ def test_bucket_list_prefix_unreadable():
     key_names = ['foo/bar', 'foo/baz', 'quux']
     bucket_name = _create_objects(keys=key_names)
     client = get_client()
+    # (Some versions of) botocore will include encoding-type=url
+    # but not decode the reflected Prefix. Work around that.
+    if hasattr(botocore.handlers, 'set_list_objects_encoding_type_url'):
+        client.meta.events.unregister(
+            'before-parameter-build.s3.ListObjects',
+            botocore.handlers.set_list_objects_encoding_type_url)
 
     response = client.list_objects(Bucket=bucket_name, Prefix='\x0a')
     eq(response['Prefix'], '\x0a')


### PR DESCRIPTION
Following https://github.com/boto/botocore/pull/726, `list_objects` will automatically include a `encoding-type=url` query param. However, the client does not decode all of the response elements properly -- notably, `Prefix` would remain encoded.

Hopefully this will be fixed soon-ish (I've got a patch proposed at https://github.com/boto/botocore/pull/1901) but in the meantime, use the work-around suggested in https://github.com/boto/boto3/issues/816 of unregistering the `set_list_objects_encoding_type_url` handler.