### PR TITLE
bootstrap: add support for *suse distributions

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -3,39 +3,60 @@ set -e
 
 virtualenv="virtualenv"
 declare -a packages
-if [ -f /etc/debian_version ]; then
-    packages=(debianutils python3-pip python3-virtualenv python3-dev libevent-dev libffi-dev libxml2-dev libxslt-dev zlib1g-dev)
-    for package in ${packages[@]}; do
-        if [ "$(dpkg --status -- $package 2>/dev/null|sed -n 's/^Status: //p')" != "install ok installed" ]; then
-            # add a space after old values
-            missing="${missing:+$missing }$package"
-        fi
-    done
+source /etc/os-release
 
-    if [ -n "$missing" ]; then
-        echo "$0: missing required DEB packages. Installing via sudo." 1>&2
-        sudo apt-get -y install $missing
-    fi
-elif [ -f /etc/redhat-release ]; then
-    packages=(which python3-virtualenv python36-devel libevent-devel libffi-devel libxml2-devel libxslt-devel zlib-devel)
-    for package in ${packages[@]}; do
-        # When the package is python36-devel we change it to python3-devel on Fedora
-        if [[ ${package} == "python36-devel" && -f /etc/fedora-release ]]; then
+case "$ID" in
+    debian|ubuntu|devuan)
+        packages=(debianutils python3-pip python3-virtualenv python3-dev libevent-dev libffi-dev libxml2-dev libxslt-dev zlib1g-dev)
+        for package in ${packages[@]}; do
+            if [ "$(dpkg --status -- $package 2>/dev/null|sed -n 's/^Status: //p')" != "install ok installed" ]; then
+                # add a space after old values
+                missing="${missing:+$missing }$package"
+            fi
+        done
+
+        if [ -n "$missing" ]; then
+            echo "$0: missing required DEB packages. Installing via sudo." 1>&2
+            sudo apt-get -y install $missing
+        fi
+        ;;
+    centos|fedora|rhel|ol|virtuozzo)
+
+        packages=(which python3-virtualenv python36-devel libevent-devel libffi-devel libxml2-devel libxslt-devel zlib-devel)
+        for package in ${packages[@]}; do
+            # When the package is python36-devel we change it to python3-devel on Fedora
+            if [[ ${package} == "python36-devel" && -f /etc/fedora-release ]]; then
                 package=python36
-        fi
-        if [ "$(rpm -qa $package 2>/dev/null)" == "" ]; then
-            missing="${missing:+$missing }$package"
-        fi
-    done
+            fi
+            if [ "$(rpm -qa $package 2>/dev/null)" == "" ]; then
+                missing="${missing:+$missing }$package"
+            fi
+        done
 
-    if [ -n "$missing" ]; then
-        echo "$0: Missing required RPM packages: ${missing}." 1>&2
-        sudo yum -y install $missing
-    fi
-else
-    echo "s3-tests can only be run on Red Hat, Centos, Fedora, Ubunutu, or Debian platforms"
-    exit 1
-fi
+        if [ -n "$missing" ]; then
+            echo "$0: Missing required RPM packages: ${missing}." 1>&2
+            sudo yum -y install $missing
+        fi
+        ;;
+    opensuse*|suse|sles)
+
+        packages=(which python3-virtualenv python3-devel libev-devel libffi-devel libxml2-devel libxslt-devel zlib-devel)
+        for package in ${packages[@]}; do
+            if [ "$(rpm -qa $package 2>/dev/null)" == "" ]; then
+                missing="${missing:+$missing }$package"
+            fi
+            if [ -n "$missing" ]; then
+                echo "$0: Missing required RPM packages: ${missing}." 1>&2
+                sudo zypper --non-interactive install --no-recommends $missing
+            fi
+        done
+
+        ;;
+    *)
+        echo "Bootstrap script does not support this distro yet, consider adding the packages"
+        exit 1
+esac
+
 
 # s3-tests only works on python 3.6 not newer versions of python3
 ${virtualenv} --python=$(which python3.6) --no-site-packages --distribute virtualenv


### PR DESCRIPTION
Also reformatted the bootstrap script to parse /etc/os-release instead, so that
more distro/pkg manager support could be added at a later point in time and
fixed the error message

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>