### PR TITLE
Fixed ERROR in test_basic_key_count

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -190,8 +190,8 @@ def test_basic_key_count():
     for j in range(5):
             client.put_object(Bucket=bucket_name, Key=str(j))
     response1 = client.list_objects_v2(Bucket=bucket_name)
+    eq('KeyCount' in response1, True)
     eq(response1['KeyCount'], 5)
-
 
 
 @attr(resource='bucket')


### PR DESCRIPTION
Very small fix for the test to FAIL instead of ERROR when expected field is missing from response.

Signed-off-by: Bartosz Rabiega <bartosz.rabiega@corp.ovh.com>