### PR TITLE
Fix: Bucket resource leak when cleanup

### DIFF
--- a/s3tests_boto3/functional/__init__.py
+++ b/s3tests_boto3/functional/__init__.py
@@ -113,6 +113,7 @@ def nuke_prefixed_buckets(prefix, client=None):
 
     buckets = get_buckets_list(client, prefix)
 
+    err = None
     if buckets != []:
         for bucket_name in buckets:
             objects_list = get_objects_list(bucket_name, client)
@@ -126,11 +127,15 @@ def nuke_prefixed_buckets(prefix, client=None):
                 response = client.delete_object(Bucket=bucket_name,Key=obj[0],VersionId=obj[1])
             try:
                 response = client.delete_bucket(Bucket=bucket_name)
-            except ClientError:
-                # if DELETE times out, the retry may see NoSuchBucket
-                if response['Error']['Code'] != 'NoSuchBucket':
-                    raise ClientError
+            except ClientError as e:
+                # The exception shouldn't be raised when doing cleanup. Pass and continue
+                # the bucket cleanup process. Otherwise left buckets wouldn't be cleared
+                # resulting in some kind of resource leak. err is used to hint user some
+                # exception once occurred.
+                err = e
                 pass
+        if err:
+            raise err
 
     print('Done with cleanup of buckets in tests.')
 


### PR DESCRIPTION
In the function of nuke_prefixed_buckets, if some err is thrown when deleting buckets, the left buckets remain uncleaned.
It is kind of resoruce leak on some charged platform. We have to clear them manually.

I know the original code is meant to give the user some hint by rasing error. But the resource leak of left buckets is a little annoying.

Signed-off-by: Pei <huangp0600@126.com>