### PR TITLE
fix/restore test_lifecycle_expiration checks

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -8938,9 +8938,9 @@ def test_lifecycle_expiration():
     expire3_objects = response['Contents']
 
     eq(len(init_objects), 6)
-    eq(len(expire1_objects), 6)
-    eq(len(keep2_objects), 6)
-    eq(len(expire3_objects), 6)
+    eq(len(expire1_objects), 4)
+    eq(len(keep2_objects), 4)
+    eq(len(expire3_objects), 2)
 
 @attr(resource='bucket')
 @attr(method='put')
@@ -8977,7 +8977,6 @@ def test_lifecyclev2_expiration():
     eq(len(keep2_objects), 4)
     eq(len(expire3_objects), 2)
 
-
 @attr(resource='bucket')
 @attr(method='put')
 @attr(operation='test lifecycle expiration on versining enabled bucket')
@@ -9001,7 +9000,6 @@ def test_lifecycle_expiration_versioning_enabled():
     delete_markers = response['DeleteMarkers']
     eq(len(versions), 1)
     eq(len(delete_markers), 1)
-
 
 @attr(resource='bucket')
 @attr(method='put')


### PR DESCRIPTION
Commit bf956df71e56bcdae7d41b9789d8e8d775f76007 adding
listobvjectsv2 tests inadvertently changed the v1
test_lifecycle_expiration test, which it had copied to
create a v2 version.  Revert this.

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>