### PR TITLE
bootstrap: remove deprecated virtualenv options

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -59,7 +59,7 @@ esac
 
 
 # s3-tests only works on python 3.6 not newer versions of python3
-${virtualenv} --python=$(which python3.6) --no-site-packages --distribute virtualenv
+${virtualenv} --python=$(which python3.6) virtualenv
 
 # avoid pip bugs
 ./virtualenv/bin/pip3 install --upgrade pip


### PR DESCRIPTION
this fails on Ubuntu 20.04:

> virtualenv: error: unrecognized arguments: --no-site-packages --distribute

according to `virtualenv -h`:
```
  --no-site-packages    DEPRECATED. Retained only for backward compatibility.
                        Not having access to global site-packages is now the
                        default behavior.
  --distribute          DEPRECATED. Retained only for backward compatibility.
                        This option has no effect.
```