### PR TITLE
Use marker when calling list_objects

### DIFF
--- a/s3tests_boto3/functional/__init__.py
+++ b/s3tests_boto3/functional/__init__.py
@@ -61,16 +61,28 @@ def get_objects_list(bucket, client=None, prefix=None):
     if client == None:
         client = get_client()
 
-    if prefix == None:
-        response = client.list_objects(Bucket=bucket)
-    else:
-        response = client.list_objects(Bucket=bucket, Prefix=prefix)
     objects_list = []
+    marker = None
+    while True:
+        if prefix == None:
+            if marker == None:
+                response = client.list_objects(Bucket=bucket)
+            else:
+                response = client.list_objects(Bucket=bucket, Marker=marker)
+        else:
+            if marker == None:
+                response = client.list_objects(Bucket=bucket, Prefix=prefix)
+            else:
+                response = client.list_objects(Bucket=bucket, Prefix=prefix, Marker=marker)
 
-    if 'Contents' in response:
-        contents = response['Contents']
-        for obj in contents:
-            objects_list.append(obj['Key'])
+        if 'Contents' in response:
+            contents = response['Contents']
+            for obj in contents:
+                objects_list.append(obj['Key'])
+
+        marker = response.get('NextMarker')
+        if marker == None:
+            break
 
     return objects_list
 


### PR DESCRIPTION
Previously `test_bucket_list_delimiter_not_skip_special` failed in
`nuke_buckets` due to not deleting all the keys.