### PR TITLE
[ceph-nautilus] Fix fuzzer test on big-endian systems

### DIFF
--- a/s3tests/fuzz/headers.py
+++ b/s3tests/fuzz/headers.py
@@ -189,7 +189,7 @@ class RepeatExpandingFormatter(string.Formatter):
         if charset_arg == 'binary' or charset_arg == 'binary_no_whitespace':
             num_bytes = length + 8
             tmplist = [self.prng.getrandbits(64) for _ in xrange(num_bytes / 8)]
-            tmpstring = struct.pack((num_bytes / 8) * 'Q', *tmplist)
+            tmpstring = struct.pack('<' + (num_bytes / 8) * 'Q', *tmplist)
             if charset_arg == 'binary_no_whitespace':
                 tmpstring = ''.join(c for c in tmpstring if c not in string.whitespace)
             return tmpstring[0:length]


### PR DESCRIPTION
Currently, the test_expand_random_binary test fails on big-endian
systems.  It turns out that this is because the special_random
routine in RepeatExpandingFormatter uses struct.pack in a manner
where the returned byte sequence depends on host byte order.

Fixed this to enforce the same output across platforms.

Note that these tests were completely removed after nautilus, so I'm sending this PR only against the ceph-nautilus branch.   (We are still running Teuthology against Ceph nautilus, and this issue causes test failures there.)