### PR TITLE
Cloud transition/tiering test cases

### DIFF
--- a/s3tests.conf.SAMPLE
+++ b/s3tests.conf.SAMPLE
@@ -53,6 +53,34 @@ access_key = NOPQRSTUVWXYZABCDEFG
 # alt AWS secret key set in vstart.sh
 secret_key = nopqrstuvwxyzabcdefghijklmnabcdefghijklm
 
+[s3 cloud]
+## to run the testcases with "cloud_transition" attribute.
+## Note: the waiting time may have to changed depending on
+## the I/O latency to the cloud endpoint.
+
+## host set for cloud endpoint
+# host = localhost
+
+## port set for cloud endpoint
+# port = 8001
+
+## cloud endpoint credentials
+# access_key = 0555b35654ad1656d804
+# secret_key = h7GhxuBLTrlhVUyxSPUKUV8r/2EI4ngqJxD7iBdBYLhwluN30JaT3Q==
+
+## storage class configured as cloud tier on local rgw server
+# cloud_storage_class = CLOUDTIER
+
+## Below are optional -
+
+## Above configured cloud storage class config options
+# retain_object = false
+# target_storage_class = Target_SC
+# target_path = cloud-bucket
+
+## another regular storage class to test multiple transition rules,
+# storage_class = S1
+
 [s3 tenant]
 # tenant display_name set in vstart.sh
 display_name = testx$tenanteduser

--- a/s3tests/functional/__init__.py
+++ b/s3tests/functional/__init__.py
@@ -324,6 +324,11 @@ def setup():
             'is_secure',
             'kms_keyid',
             'storage_classes',
+            'retain_object',
+            'cloud_storage_class',
+            'target_path',
+            'target_storage_class',
+            'storage_class',
             ]:
             try:
                 config[name][var] = cfg.get(section, var)
@@ -333,15 +338,27 @@ def setup():
         targets[name] = RegionsConn()
 
         for (k, conf) in regions.items():
-            conn = boto.s3.connection.S3Connection(
-                aws_access_key_id=cfg.get(section, 'access_key'),
-                aws_secret_access_key=cfg.get(section, 'secret_key'),
-                is_secure=conf.is_secure,
-                port=conf.port,
-                host=conf.host,
-                # TODO test vhost calling format
-                calling_format=conf.calling_format,
-                )
+            if (name == 'cloud'):
+                conn = boto.s3.connection.S3Connection(
+                    aws_access_key_id=cfg.get(section, 'access_key'),
+                    aws_secret_access_key=cfg.get(section, 'secret_key'),
+                    #is_secure=cfg.get(section, 'is_secure'),
+                    is_secure=conf.is_secure,
+                    port=int(cfg.get(section, 'port')),
+                    host=cfg.get(section, 'host'),
+                    # TODO test vhost calling format
+                    calling_format=conf.calling_format,
+                    )
+            else:
+                conn = boto.s3.connection.S3Connection(
+                    aws_access_key_id=cfg.get(section, 'access_key'),
+                    aws_secret_access_key=cfg.get(section, 'secret_key'),
+                    is_secure=conf.is_secure,
+                    port=conf.port,
+                    host=conf.host,
+                    # TODO test vhost calling format
+                    calling_format=conf.calling_format,
+                    )
 
             temp_targetConn = TargetConnection(conf, conn)
             targets[name].add(k, temp_targetConn)


### PR DESCRIPTION
Added few test cases for rgw cloud-transition/tiering feature. The sleep/waiting time in the tests may vary based on the I/O latency to the cloud endpoint.

Feature doc: https://docs.google.com/document/d/1IoeITPCF64A5W-UA-9Y3Vp2oSfz3xVQHu31GTu3u3Ug/edit#heading=h.4o1xyas8s23x

PR: https://github.com/ceph/ceph/pull/35100

Signed-off-by: Soumya Koduri <skoduri@redhat.com>