### PR TITLE
Use a source-built nose instead of one in PyPI

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -74,3 +74,7 @@ ${virtualenv} --python=$(which python3.6) virtualenv
 # requirements.txt does not match setup.py requirements -- sucky but
 # good enough for now
 ./virtualenv/bin/python3 setup.py develop
+
+# The wheel that pip installs is broken at PyPI, so use plain source.
+git clone https://github.com/nose-devs/nose.git
+(cd nose && ../virtualenv/bin/python3 setup.py develop)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 PyYAML
-nose >=1.0.0
 boto >=2.6.0
 boto3 >=1.0.0
 munch >=2.0.0


### PR DESCRIPTION
Fix crash on Fedora 35 with "AttributeError: module 'collections'
has no attribute 'Callable'". This happens because Callable is
in collections.abc in Python 3.10.

The culprit is PyPI, whence pip pulls the nose package. The nose
in Github works, the nose in Fedora works, but the wheel at PyPI
is broken. Someone hacked up the wheel that pip installs and
made a mistake. But with PyPI there's no recourse.

The maintainers disclaim any connection to the project anymore.

Our soultion is to switch to nose from the origin in github.
This may not be the best idea, because it downloads from
github on every test run.

Related-Tracker: https://tracker.ceph.com/issues/53478