### PR TITLE
Improving check_grants reliability

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -4490,12 +4490,19 @@ def check_access_denied(fn, *args, **kwargs):
     status = _get_status(e.response)
     eq(status, 403)
 
+
 def check_grants(got, want):
     """
     Check that grants list in got matches the dictionaries in want,
     in any order.
     """
     eq(len(got), len(want))
+
+    # There are instances when got does not match due the order of item.
+    if got[0]["Grantee"].get("DisplayName"):
+        got.sort(key=lambda x: x["Grantee"].get("DisplayName"))
+        want.sort(key=lambda x: x["DisplayName"])
+
     for g, w in zip(got, want):
         w = dict(w)
         g = dict(g)
@@ -4506,6 +4513,7 @@ def check_grants(got, want):
         eq(g['Grantee'].pop('URI', None), w['URI'])
         eq(g['Grantee'].pop('EmailAddress', None), w['EmailAddress'])
         eq(g, {'Grantee': {}})
+
 
 @attr(resource='bucket')
 @attr(method='get')


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

When executing S3-tests against Red Hat Ceph Storage 5.0 or downstream development builds, we have observed the following test failures

```
s3tests_boto3.functional.test_s3.test_object_acl_canned_bucketownerread ... FAIL
s3tests_boto3.functional.test_s3.test_object_acl_canned_bucketownerfullcontrol ... FAIL
```

Our analysis of the issue indicated the problem to be with dictionaries being compared. At times, the position of actual and expected dictionaries are on different positions in the list. 

This PR attempts to improve the reliability of `check_grants` method to solve the failures.

__Error log__
http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/s3/5.0-nossl/s3_tests_0.log

__Logs__
http://pastebin.test.redhat.com/1020986

__Notes__
https://github.com/ceph/s3-tests/blob/ceph-nautilus/s3tests/functional/test_s3.py#L89-L90
This check existed earlier in `ceph-nautilus` but for some reason was removed during the switch to boto3.

I think it makes sense to bring it back due to the errors seen