### PR TITLE
Fix botocore.exceptions.ParamValidationError in s3tests

### DIFF
--- a/s3tests.conf.SAMPLE
+++ b/s3tests.conf.SAMPLE
@@ -104,6 +104,6 @@ azp=<obtained after introspecting token>
 
 user_token=<access token for a user, with attribute Department=[Engineering, Marketing>]
 
-thumbprint=<obtained from x509 certificate>
+thumbprint=<obtained from x509 certificate and is longer than 40 characters>
 
 KC_REALM=<name of the realm>


### PR DESCRIPTION
When running ../qa/workunits/rgw/run-s3tests.sh, the following
is thrown on Fedora 35:

botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid length for parameter ThumbprintList[0], value: 32, valid min
length: 40

Signed-off-by: Pete Zaitcev <zaitcev@redhat.com>