### PR TITLE
lifecycle/deletemarker_expiration: Increase timer window

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -9915,7 +9915,7 @@ def test_lifecycle_deletemarker_expiration():
     lc_interval = get_lc_debug_interval()
 
     # Wait for first expiration (plus fudge to handle the timer window)
-    time.sleep(5*lc_interval)
+    time.sleep(7*lc_interval)
 
     response  = client.list_object_versions(Bucket=bucket_name)
     init_versions = response['Versions']


### PR DESCRIPTION
Increase wait time in test_lifecycle_deletemarker_expiration(..) to avoid any spurious failure.

Signed-off-by: Soumya Koduri <skoduri@redhat.com>