### PR TITLE
Fix versioning tests failures due multiple removal of object

### DIFF
--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -6854,8 +6854,9 @@ def _do_remove_versions(bucket, objname, remove_start_idx, idx_inc, head_rm_rati
 
     for j in xrange(total):
         r += head_rm_ratio
-        if r >= 1:
-            r %= 1
+
+        # Head object can be removed only once.
+        if r == 1:
             remove_obj_head(bucket, objname, k, c)
         else:
             remove_obj_version(bucket, k, c, idx)


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

We are seeing this failure when running against RHCS 4.3

```
======================================================================
FAIL: s3tests.functional.test_s3.test_versioning_obj_create_versions_remove_all
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/cephuser/s3-tests/venv/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/cephuser/s3-tests/s3tests/functional/test_s3.py", line 7148, in test_versioning_obj_create_versions_remove_all
    _do_remove_versions(bucket, objname, 0, 5, 0.5, k, c)
  File "/home/cephuser/s3-tests/s3tests/functional/test_s3.py", line 6862, in _do_remove_versions
    remove_obj_head(bucket, objname, k, c)
  File "/home/cephuser/s3-tests/s3tests/functional/test_s3.py", line 6837, in remove_obj_head
    eq(key.delete_marker, True)
AssertionError: False != True
-------------------- >> begin captured stdout << ---------------------
```

This error occurs as we attempt to remove the object more than once in the test case. This PR modifies `_do_remove_versions` method to attempt the removal once when `head_rm_ration` reaches `1` assuming that it is `100%`.

__Logs__
Failure: http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/fix_s3/failure.log
Fix: http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/fix_s3/test_with_fix.log
Complete run with fix: http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/fix_s3/full_run_with_fix.log