### PR TITLE
[ceph-pacific] Improve check_grants method to support unsorted list

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -4452,6 +4452,12 @@ def check_grants(got, want):
     in any order.
     """
     eq(len(got), len(want))
+
+    # There are instances when got does not match due the order of item.
+    if got[0]["Grantee"].get("DisplayName"):
+        got.sort(key=lambda x: x["Grantee"].get("DisplayName"))
+        want.sort(key=lambda x: x["DisplayName"])
+
     for g, w in zip(got, want):
         w = dict(w)
         g = dict(g)


### PR DESCRIPTION
Signed-off-by: Pragadeeswaran Sathyanarayanan <psathyan@redhat.com>

When executing S3-tests against Red Hat Ceph Storage 5.1 downstream development builds, we are observing the below test failures

```
s3tests_boto3.functional.test_s3.test_object_acl_canned_bucketownerread ... FAIL
s3tests_boto3.functional.test_s3.test_object_acl_canned_bucketownerfullcontrol ... FAIL
s3tests_boto3.functional.test_s3.test_bucket_acl_grant_userid_fullcontrol ... FAIL
s3tests_boto3.functional.test_s3.test_bucket_acl_grant_userid_read ... FAIL
s3tests_boto3.functional.test_s3.test_bucket_acl_grant_userid_readacp ... FAIL
s3tests_boto3.functional.test_s3.test_bucket_acl_grant_userid_write ... FAIL
s3tests_boto3.functional.test_s3.test_bucket_acl_grant_userid_writeacp ... FAIL
s3tests_boto3.functional.test_s3.test_bucket_acl_grant_email ... FAIL```
```

Our analysis of the issue indicated the problem to be with dictionaries being compared. At times, the position of actual and expected dictionaries are on different positions in the list. 

This PR attempts to improve the reliability of `check_grants` method to solve the failures.

__Logs__
Failing: http://magna002.ceph.redhat.com/ceph-qe-logs/psathyan/fix_s3/51/wofix/execute_s3tests_0.log
Fix: http://pastebin.test.redhat.com/1034247

__Notes__
The failure is inconsistent as it depends on the order in which the response is returned. 
This change exists in the master branch... raising this PR to backport the fix to `ceph-pacific` branch only