### PR TITLE
Fix wrong assertion of the test: `test_buckets_list_ctime`

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -6159,13 +6159,15 @@ def test_buckets_list_ctime():
     before = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=1)
 
     client = get_client()
+    buckets = []
     for i in range(5):
-        client.create_bucket(Bucket=get_new_bucket_name())
+        buckets.append(client.create_bucket(Bucket=get_new_bucket_name()))
 
     response = client.list_buckets()
     for bucket in response['Buckets']:
-        ctime = bucket['CreationDate']
-        assert before <= ctime, '%r > %r' % (before, ctime)
+        if bucket['Name'] in buckets:
+            ctime = bucket['CreationDate']
+            assert before <= ctime, '%r > %r' % (before, ctime)
 
 @attr(resource='bucket')
 @attr(method='get')


### PR DESCRIPTION
**TestName:**
s3tests_boto3.functional.test_s3:test_buckets_list_ctime

**Problem:**
The test creates 5 buckets for a user but in an assertion check, 
it asserts false if any bucket of the user has CreationTime less than a day prior to the current time.
Due to this reason, the test fails if the user has pre-existing buckets older than a day.

**Solution:**
Assert only on the CreationTime of buckets that were created with test execution.