### PR TITLE
Add support for rocky linux in bootstrap

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -20,7 +20,7 @@ case "$ID" in
             sudo apt-get -y install $missing
         fi
         ;;
-    centos|fedora|rhel|ol|virtuozzo)
+    centos|fedora|rhel|rocky|ol|virtuozzo)
 
         packages=(which python3-virtualenv python36-devel libevent-devel libffi-devel libxml2-devel libxslt-devel zlib-devel)
         for package in ${packages[@]}; do


### PR DESCRIPTION
I tried running this inside rocky linux and it complained that it was not supported. Rocky in the EL family so I added the name there.