### PR TITLE
Tag testcases failing on dbstore with 'fails_on_dbstore' attr

### DIFF
--- a/s3tests/functional/test_headers.py
+++ b/s3tests/functional/test_headers.py
@@ -182,6 +182,7 @@ def tag(*tags):
 @attr(method='put')
 @attr(operation='create w/no content length')
 @attr(assertion='fails 411')
+@attr('fails_on_dbstore')
 @nose.with_setup(teardown=_clear_custom_headers)
 def test_object_create_bad_contentlength_none():
     key = _setup_bad_object(remove=('Content-Length',))
@@ -221,6 +222,7 @@ def test_object_create_bad_contentlength_mismatch_above():
 @attr(method='put')
 @attr(operation='create w/empty authorization')
 @attr(assertion='fails 403')
+@attr('fails_on_dbstore')
 @nose.with_setup(teardown=_clear_custom_headers)
 def test_object_create_bad_authorization_empty():
     key = _setup_bad_object({'Authorization': ''})
@@ -235,6 +237,7 @@ def test_object_create_bad_authorization_empty():
 @attr(method='put')
 @attr(operation='create w/date and x-amz-date')
 @attr(assertion='succeeds')
+@attr('fails_on_dbstore')
 @nose.with_setup(teardown=_clear_custom_headers)
 def test_object_create_date_and_amz_date():
     date = formatdate(usegmt=True)
@@ -246,6 +249,7 @@ def test_object_create_date_and_amz_date():
 @attr(method='put')
 @attr(operation='create w/x-amz-date and no date')
 @attr(assertion='succeeds')
+@attr('fails_on_dbstore')
 @nose.with_setup(teardown=_clear_custom_headers)
 def test_object_create_amz_date_and_no_date():
     date = formatdate(usegmt=True)
@@ -259,6 +263,7 @@ def test_object_create_amz_date_and_no_date():
 @attr(method='put')
 @attr(operation='create w/no authorization')
 @attr(assertion='fails 403')
+@attr('fails_on_dbstore')
 @nose.with_setup(teardown=_clear_custom_headers)
 def test_object_create_bad_authorization_none():
     key = _setup_bad_object(remove=('Authorization',))
@@ -274,6 +279,7 @@ def test_object_create_bad_authorization_none():
 @attr(method='put')
 @attr(operation='create w/no content length')
 @attr(assertion='succeeds')
+@attr('fails_on_dbstore')
 @nose.with_setup(teardown=_clear_custom_headers)
 def test_bucket_create_contentlength_none():
     _add_custom_headers(remove=('Content-Length',))
@@ -285,6 +291,7 @@ def test_bucket_create_contentlength_none():
 @attr(method='acls')
 @attr(operation='set w/no content length')
 @attr(assertion='succeeds')
+@attr('fails_on_dbstore')
 @nose.with_setup(teardown=_clear_custom_headers)
 def test_object_acl_create_contentlength_none():
     bucket = get_new_bucket()
@@ -328,6 +335,7 @@ def test_bucket_create_bad_contentlength_empty():
 @attr(method='put')
 @attr(operation='create w/no content length')
 @attr(assertion='succeeds')
+@attr('fails_on_dbstore')
 @nose.with_setup(teardown=_clear_custom_headers)
 def test_bucket_create_bad_contentlength_none():
     _add_custom_headers(remove=('Content-Length',))
@@ -339,6 +347,7 @@ def test_bucket_create_bad_contentlength_none():
 @attr(method='put')
 @attr(operation='create w/empty authorization')
 @attr(assertion='fails 403')
+@attr('fails_on_dbstore')
 @nose.with_setup(teardown=_clear_custom_headers)
 def test_bucket_create_bad_authorization_empty():
     _add_custom_headers({'Authorization': ''})
@@ -354,6 +363,7 @@ def test_bucket_create_bad_authorization_empty():
 @attr(method='put')
 @attr(operation='create w/no authorization')
 @attr(assertion='fails 403')
+@attr('fails_on_dbstore')
 @nose.with_setup(teardown=_clear_custom_headers)
 def test_bucket_create_bad_authorization_none():
     _add_custom_headers(remove=('Authorization',))
@@ -371,6 +381,7 @@ def test_bucket_create_bad_authorization_none():
 @attr(method='put')
 @attr(operation='create w/content length too short')
 @attr(assertion='fails 400')
+@attr('fails_on_dbstore')
 @nose.with_setup(teardown=_clear_custom_headers)
 def test_object_create_bad_contentlength_mismatch_below_aws2():
     check_aws2_support()
@@ -388,6 +399,7 @@ def test_object_create_bad_contentlength_mismatch_below_aws2():
 @attr(method='put')
 @attr(operation='create w/incorrect authorization')
 @attr(assertion='fails 403')
+@attr('fails_on_dbstore')
 @nose.with_setup(teardown=_clear_custom_headers)
 def test_object_create_bad_authorization_incorrect_aws2():
     check_aws2_support()
@@ -404,6 +416,7 @@ def test_object_create_bad_authorization_incorrect_aws2():
 @attr(method='put')
 @attr(operation='create w/invalid authorization')
 @attr(assertion='fails 400')
+@attr('fails_on_dbstore')
 def test_object_create_bad_authorization_invalid_aws2():
     check_aws2_support()
     key = _setup_bad_object({'Authorization': 'AWS HAHAHA'})
@@ -417,6 +430,7 @@ def test_object_create_bad_authorization_invalid_aws2():
 @attr(method='put')
 @attr(operation='create w/no date')
 @attr(assertion='fails 403')
+@attr('fails_on_dbstore')
 @nose.with_setup(teardown=_clear_custom_headers)
 def test_object_create_bad_date_none_aws2():
     check_aws2_support()
@@ -446,6 +460,7 @@ def test_bucket_create_bad_authorization_invalid_aws2():
 @attr(method='put')
 @attr(operation='create w/no date')
 @attr(assertion='fails 403')
+@attr('fails_on_dbstore')
 @nose.with_setup(teardown=_clear_custom_headers)
 def test_bucket_create_bad_date_none_aws2():
     check_aws2_support()

--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -133,6 +133,7 @@ def check_configure_versioning_retry(bucket, status, expected_string):
 @attr(operation='create versioned object, read not exist null version')
 @attr(assertion='read null version behaves correctly')
 @attr('versioning')
+@attr('fails_on_dbstore')
 def test_versioning_obj_read_not_exist_null():
     bucket = get_new_bucket()
     check_versioning(bucket, None)
@@ -155,6 +156,7 @@ def test_versioning_obj_read_not_exist_null():
 @attr('fails_on_aws')
 @attr('fails_with_subdomain')
 @attr('appendobject')
+@attr('fails_on_dbstore')
 def test_append_object():
     bucket = get_new_bucket()
     key = bucket.new_key('foo')
@@ -179,6 +181,7 @@ def test_append_object():
 @attr('fails_on_aws')
 @attr('fails_with_subdomain')
 @attr('appendobject')
+@attr('fails_on_dbstore')
 def test_append_normal_object():
     bucket = get_new_bucket()
     key = bucket.new_key('foo')
@@ -199,6 +202,7 @@ def test_append_normal_object():
 @attr('fails_on_aws')
 @attr('fails_with_subdomain')
 @attr('appendobject')
+@attr('fails_on_dbstore')
 def test_append_object_position_wrong():
     bucket = get_new_bucket()
     key = bucket.new_key('foo')
@@ -402,6 +406,7 @@ def lc_transitions(transitions=None):
 @attr(operation='test create object with storage class')
 @attr('storage_class')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_object_storage_class():
     sc = configured_storage_classes()
     if len(sc) < 2:
@@ -420,6 +425,7 @@ def test_object_storage_class():
 @attr(operation='test create multipart object with storage class')
 @attr('storage_class')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_object_storage_class_multipart():
     sc = configured_storage_classes()
     if len(sc) < 2:
@@ -461,6 +467,7 @@ def _do_test_object_modify_storage_class(obj_write_func, size):
 @attr(operation='test changing objects storage class')
 @attr('storage_class')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_object_modify_storage_class():
     _do_test_object_modify_storage_class(_populate_key, size=9*1024*1024)
 
@@ -470,6 +477,7 @@ def test_object_modify_storage_class():
 @attr(operation='test changing objects storage class')
 @attr('storage_class')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_object_modify_storage_class_multipart():
     _do_test_object_modify_storage_class(_populate_multipart_key, size=11*1024*1024)
 
@@ -499,6 +507,7 @@ def _do_test_object_storage_class_copy(obj_write_func, size):
 @attr(operation='test copy object to object with different storage class')
 @attr('storage_class')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_object_storage_class_copy():
     _do_test_object_storage_class_copy(_populate_key, size=9*1024*1024)
 
@@ -507,6 +516,7 @@ def test_object_storage_class_copy():
 @attr(operation='test changing objects storage class')
 @attr('storage_class')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_object_storage_class_copy_multipart():
     _do_test_object_storage_class_copy(_populate_multipart_key, size=9*1024*1024)
 
@@ -613,6 +623,7 @@ def _test_atomic_dual_conditional_write(file_size):
 @attr(operation='write one or the other')
 @attr(assertion='1MB successful')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_atomic_dual_conditional_write_1mb():
     _test_atomic_dual_conditional_write(1024*1024)
 
@@ -621,6 +632,7 @@ def test_atomic_dual_conditional_write_1mb():
 @attr(operation='write file in deleted bucket')
 @attr(assertion='fail 404')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_atomic_write_bucket_gone():
     bucket = get_new_bucket()
 
@@ -665,6 +677,7 @@ def _multipart_upload_enc(bucket, s3_key_name, size, part_size=5*1024*1024,
 @attr(operation='multipart upload with bad key for uploading chunks')
 @attr(assertion='successful')
 @attr('encryption')
+@attr('fails_on_dbstore')
 def test_encryption_sse_c_multipart_invalid_chunks_1():
     bucket = get_new_bucket()
     key = "multipart_enc"
@@ -692,6 +705,7 @@ def test_encryption_sse_c_multipart_invalid_chunks_1():
 @attr(operation='multipart upload with bad md5 for chunks')
 @attr(assertion='successful')
 @attr('encryption')
+@attr('fails_on_dbstore')
 def test_encryption_sse_c_multipart_invalid_chunks_2():
     bucket = get_new_bucket()
     key = "multipart_enc"
@@ -720,6 +734,7 @@ def test_encryption_sse_c_multipart_invalid_chunks_2():
 @attr(assertion='succeeds')
 @attr('fails_with_subdomain')
 @attr('bucket-policy')
+@attr('fails_on_dbstore')
 def test_bucket_policy_different_tenant():
     bucket = get_new_bucket()
     key = bucket.new_key('asdf')
@@ -758,6 +773,7 @@ def test_bucket_policy_different_tenant():
 @attr(method='put')
 @attr(operation='Test put condition operator end with ifExists')
 @attr('bucket-policy')
+@attr('fails_on_dbstore')
 def test_bucket_policy_set_condition_operator_end_with_IfExists():
     bucket = _create_keys(keys=['foo'])
     policy = '''{
@@ -798,6 +814,7 @@ def _make_arn_resource(path="*"):
 @attr(assertion='success')
 @attr('encryption')
 @attr('bucket-policy')
+@attr('fails_on_dbstore')
 def test_bucket_policy_put_obj_enc():
 
     bucket = get_new_bucket()
@@ -843,6 +860,7 @@ def test_bucket_policy_put_obj_enc():
 @attr(assertion='success')
 @attr('tagging')
 @attr('bucket-policy')
+@attr('fails_on_dbstore')
 def test_bucket_policy_put_obj_request_obj_tag():
 
     bucket = get_new_bucket()

--- a/s3tests/functional/test_s3_website.py
+++ b/s3tests/functional/test_s3_website.py
@@ -43,6 +43,7 @@ ERRORDOC_TEMPLATE = '<html><h1>ErrorDoc</h1><body>{random}</body></html>'
 
 CAN_WEBSITE = None
 
+@attr('fails_on_dbstore')
 def check_can_test_website():
     global CAN_WEBSITE
     # This is a bit expensive, so we cache this
@@ -265,6 +266,7 @@ def test_website_nonexistant_bucket_s3():
 @attr(assertion='non-existant bucket via website endpoint should give NoSuchBucket')
 @attr('s3website')
 @attr('fails_on_s3')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_website_nonexistant_bucket_rgw():
     bucket_name = get_new_bucket_name()
@@ -278,6 +280,7 @@ def test_website_nonexistant_bucket_rgw():
 @attr(operation='list')
 @attr(assertion='non-empty public buckets via s3website return page for /, where page is public')
 @attr('s3website')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 @timed(10)
 def test_website_public_bucket_list_public_index():
@@ -306,6 +309,7 @@ def test_website_public_bucket_list_public_index():
 @attr(operation='list')
 @attr(assertion='non-empty private buckets via s3website return page for /, where page is private')
 @attr('s3website')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_website_private_bucket_list_public_index():
     bucket = get_new_bucket()
@@ -336,6 +340,7 @@ def test_website_private_bucket_list_public_index():
 @attr(operation='list')
 @attr(assertion='empty private buckets via s3website return a 403 for /')
 @attr('s3website')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_website_private_bucket_list_empty():
     bucket = get_new_bucket()
@@ -352,6 +357,7 @@ def test_website_private_bucket_list_empty():
 @attr(operation='list')
 @attr(assertion='empty public buckets via s3website return a 404 for /')
 @attr('s3website')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_website_public_bucket_list_empty():
     bucket = get_new_bucket()
@@ -367,6 +373,7 @@ def test_website_public_bucket_list_empty():
 @attr(operation='list')
 @attr(assertion='non-empty public buckets via s3website return page for /, where page is private')
 @attr('s3website')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_website_public_bucket_list_private_index():
     bucket = get_new_bucket()
@@ -392,6 +399,7 @@ def test_website_public_bucket_list_private_index():
 @attr(operation='list')
 @attr(assertion='non-empty private buckets via s3website return page for /, where page is private')
 @attr('s3website')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_website_private_bucket_list_private_index():
     bucket = get_new_bucket()
@@ -418,6 +426,7 @@ def test_website_private_bucket_list_private_index():
 @attr(operation='list')
 @attr(assertion='empty private buckets via s3website return a 403 for /, missing errordoc')
 @attr('s3website')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_website_private_bucket_list_empty_missingerrordoc():
     bucket = get_new_bucket()
@@ -434,6 +443,7 @@ def test_website_private_bucket_list_empty_missingerrordoc():
 @attr(operation='list')
 @attr(assertion='empty public buckets via s3website return a 404 for /, missing errordoc')
 @attr('s3website')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_website_public_bucket_list_empty_missingerrordoc():
     bucket = get_new_bucket()
@@ -449,6 +459,7 @@ def test_website_public_bucket_list_empty_missingerrordoc():
 @attr(operation='list')
 @attr(assertion='non-empty public buckets via s3website return page for /, where page is private, missing errordoc')
 @attr('s3website')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_website_public_bucket_list_private_index_missingerrordoc():
     bucket = get_new_bucket()
@@ -473,6 +484,7 @@ def test_website_public_bucket_list_private_index_missingerrordoc():
 @attr(operation='list')
 @attr(assertion='non-empty private buckets via s3website return page for /, where page is private, missing errordoc')
 @attr('s3website')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_website_private_bucket_list_private_index_missingerrordoc():
     bucket = get_new_bucket()
@@ -498,6 +510,7 @@ def test_website_private_bucket_list_private_index_missingerrordoc():
 @attr(operation='list')
 @attr(assertion='empty private buckets via s3website return a 403 for /, blocked errordoc')
 @attr('s3website')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_website_private_bucket_list_empty_blockederrordoc():
     bucket = get_new_bucket()
@@ -526,6 +539,7 @@ def test_website_private_bucket_list_empty_blockederrordoc():
 @attr(operation='list')
 @attr(assertion='check if there is an invalid payload after serving error doc')
 @attr('s3website')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_website_public_bucket_list_pubilc_errordoc():
     bucket = get_new_bucket()
@@ -577,6 +591,7 @@ def test_website_public_bucket_list_pubilc_errordoc():
 @attr(operation='list')
 @attr(assertion='empty public buckets via s3website return a 404 for /, blocked errordoc')
 @attr('s3website')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_website_public_bucket_list_empty_blockederrordoc():
     bucket = get_new_bucket()
@@ -604,6 +619,7 @@ def test_website_public_bucket_list_empty_blockederrordoc():
 @attr(operation='list')
 @attr(assertion='non-empty public buckets via s3website return page for /, where page is private, blocked errordoc')
 @attr('s3website')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_website_public_bucket_list_private_index_blockederrordoc():
     bucket = get_new_bucket()
@@ -637,6 +653,7 @@ def test_website_public_bucket_list_private_index_blockederrordoc():
 @attr(operation='list')
 @attr(assertion='non-empty private buckets via s3website return page for /, where page is private, blocked errordoc')
 @attr('s3website')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_website_private_bucket_list_private_index_blockederrordoc():
     bucket = get_new_bucket()
@@ -672,6 +689,7 @@ def test_website_private_bucket_list_private_index_blockederrordoc():
 @attr(assertion='empty private buckets via s3website return a 403 for /, good errordoc')
 @attr('s3website')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
+@attr('fails_on_dbstore')
 def test_website_private_bucket_list_empty_gooderrordoc():
     bucket = get_new_bucket()
     f = _test_website_prep(bucket, WEBSITE_CONFIGS_XMLFRAG['IndexDocErrorDoc'])
@@ -694,6 +712,7 @@ def test_website_private_bucket_list_empty_gooderrordoc():
 @attr(operation='list')
 @attr(assertion='empty public buckets via s3website return a 404 for /, good errordoc')
 @attr('s3website')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_website_public_bucket_list_empty_gooderrordoc():
     bucket = get_new_bucket()
@@ -718,6 +737,7 @@ def test_website_public_bucket_list_empty_gooderrordoc():
 @attr(operation='list')
 @attr(assertion='non-empty public buckets via s3website return page for /, where page is private')
 @attr('s3website')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_website_public_bucket_list_private_index_gooderrordoc():
     bucket = get_new_bucket()
@@ -747,6 +767,7 @@ def test_website_public_bucket_list_private_index_gooderrordoc():
 @attr(operation='list')
 @attr(assertion='non-empty private buckets via s3website return page for /, where page is private')
 @attr('s3website')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_website_private_bucket_list_private_index_gooderrordoc():
     bucket = get_new_bucket()
@@ -777,6 +798,7 @@ def test_website_private_bucket_list_private_index_gooderrordoc():
 @attr(operation='list')
 @attr(assertion='RedirectAllRequestsTo without protocol should TODO')
 @attr('s3website')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_website_bucket_private_redirectall_base():
     bucket = get_new_bucket()
@@ -794,6 +816,7 @@ def test_website_bucket_private_redirectall_base():
 @attr(operation='list')
 @attr(assertion='RedirectAllRequestsTo without protocol should TODO')
 @attr('s3website')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_website_bucket_private_redirectall_path():
     bucket = get_new_bucket()
@@ -813,6 +836,7 @@ def test_website_bucket_private_redirectall_path():
 @attr(operation='list')
 @attr(assertion='RedirectAllRequestsTo without protocol should TODO')
 @attr('s3website')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_website_bucket_private_redirectall_path_upgrade():
     bucket = get_new_bucket()
@@ -835,6 +859,7 @@ def test_website_bucket_private_redirectall_path_upgrade():
 @attr(assertion='x-amz-website-redirect-location should not fire without websiteconf')
 @attr('s3website')
 @attr('x-amz-website-redirect-location')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_website_xredirect_nonwebsite():
     bucket = get_new_bucket()
@@ -867,6 +892,7 @@ def test_website_xredirect_nonwebsite():
 @attr(assertion='x-amz-website-redirect-location should fire websiteconf, relative path, public key')
 @attr('s3website')
 @attr('x-amz-website-redirect-location')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_website_xredirect_public_relative():
     bucket = get_new_bucket()
@@ -894,6 +920,7 @@ def test_website_xredirect_public_relative():
 @attr(assertion='x-amz-website-redirect-location should fire websiteconf, absolute, public key')
 @attr('s3website')
 @attr('x-amz-website-redirect-location')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_website_xredirect_public_abs():
     bucket = get_new_bucket()
@@ -921,6 +948,7 @@ def test_website_xredirect_public_abs():
 @attr(assertion='x-amz-website-redirect-location should fire websiteconf, relative path, private key')
 @attr('s3website')
 @attr('x-amz-website-redirect-location')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_website_xredirect_private_relative():
     bucket = get_new_bucket()
@@ -948,6 +976,7 @@ def test_website_xredirect_private_relative():
 @attr(assertion='x-amz-website-redirect-location should fire websiteconf, absolute, private key')
 @attr('s3website')
 @attr('x-amz-website-redirect-location')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_website_xredirect_private_abs():
     bucket = get_new_bucket()
@@ -1211,6 +1240,7 @@ def routing_check(*args, **kwargs):
 
 @attr('s3website_RoutingRules')
 @attr('s3website')
+@attr('fails_on_dbstore')
 @nose.with_setup(setup=check_can_test_website, teardown=common.teardown)
 def test_routing_generator():
     for t in ROUTING_RULES_TESTS:

--- a/s3tests_boto3/functional/test_headers.py
+++ b/s3tests_boto3/functional/test_headers.py
@@ -520,6 +520,7 @@ def test_bucket_create_bad_authorization_none():
 @attr(method='put')
 @attr(operation='create w/invalid MD5')
 @attr(assertion='fails 400')
+@attr('fails_on_dbstore')
 def test_object_create_bad_md5_invalid_garbage_aws2():
     v2_client = get_v2_client()
     headers = {'Content-MD5': 'AWS HAHAHA'}
@@ -580,6 +581,7 @@ def test_object_create_bad_authorization_invalid_aws2():
 @attr(method='put')
 @attr(operation='create w/empty user agent')
 @attr(assertion='succeeds')
+@attr('fails_on_dbstore')
 def test_object_create_bad_ua_empty_aws2():
     v2_client = get_v2_client()
     headers = {'User-Agent': ''}
@@ -591,6 +593,7 @@ def test_object_create_bad_ua_empty_aws2():
 @attr(method='put')
 @attr(operation='create w/no user agent')
 @attr(assertion='succeeds')
+@attr('fails_on_dbstore')
 def test_object_create_bad_ua_none_aws2():
     v2_client = get_v2_client()
     remove = 'User-Agent'
@@ -602,6 +605,7 @@ def test_object_create_bad_ua_none_aws2():
 @attr(method='put')
 @attr(operation='create w/invalid date')
 @attr(assertion='fails 403')
+@attr('fails_on_dbstore')
 def test_object_create_bad_date_invalid_aws2():
     v2_client = get_v2_client()
     headers = {'x-amz-date': 'Bad Date'}
@@ -615,6 +619,7 @@ def test_object_create_bad_date_invalid_aws2():
 @attr(method='put')
 @attr(operation='create w/empty date')
 @attr(assertion='fails 403')
+@attr('fails_on_dbstore')
 def test_object_create_bad_date_empty_aws2():
     v2_client = get_v2_client()
     headers = {'x-amz-date': ''}
@@ -643,6 +648,7 @@ def test_object_create_bad_date_none_aws2():
 @attr(method='put')
 @attr(operation='create w/date in past')
 @attr(assertion='fails 403')
+@attr('fails_on_dbstore')
 def test_object_create_bad_date_before_today_aws2():
     v2_client = get_v2_client()
     headers = {'x-amz-date': 'Tue, 07 Jul 2010 21:53:04 GMT'}
@@ -656,6 +662,7 @@ def test_object_create_bad_date_before_today_aws2():
 @attr(method='put')
 @attr(operation='create w/date before epoch')
 @attr(assertion='fails 403')
+@attr('fails_on_dbstore')
 def test_object_create_bad_date_before_epoch_aws2():
     v2_client = get_v2_client()
     headers = {'x-amz-date': 'Tue, 07 Jul 1950 21:53:04 GMT'}
@@ -669,6 +676,7 @@ def test_object_create_bad_date_before_epoch_aws2():
 @attr(method='put')
 @attr(operation='create w/date after 9999')
 @attr(assertion='fails 403')
+@attr('fails_on_dbstore')
 def test_object_create_bad_date_after_end_aws2():
     v2_client = get_v2_client()
     headers = {'x-amz-date': 'Tue, 07 Jul 9999 21:53:04 GMT'}

--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -106,6 +106,7 @@ def test_bucket_list_empty():
 @attr(method='get')
 @attr(operation='list')
 @attr(assertion='distinct buckets have different contents')
+@attr('list-objects-v2')
 def test_bucket_list_distinct():
     bucket1 = get_new_bucket_resource()
     bucket2 = get_new_bucket_resource()
@@ -152,6 +153,7 @@ def _get_prefixes(response):
 @attr(method='get')
 @attr(operation='list all keys')
 @attr(assertion='pagination w/max_keys=2, no marker')
+@attr('fails_on_dbstore')
 def test_bucket_list_many():
     bucket_name = _create_objects(keys=['foo', 'bar', 'baz'])
     client = get_client()
@@ -173,6 +175,7 @@ def test_bucket_list_many():
 @attr(operation='list all keys')
 @attr(assertion='pagination w/max_keys=2, no marker')
 @attr('list-objects-v2')
+@attr('fails_on_dbstore')
 def test_bucket_listv2_many():
     bucket_name = _create_objects(keys=['foo', 'bar', 'baz'])
     client = get_client()
@@ -208,6 +211,7 @@ def test_basic_key_count():
 @attr(method='get')
 @attr(operation='list')
 @attr(assertion='prefixes in multi-component object names')
+@attr('fails_on_dbstore')
 def test_bucket_list_delimiter_basic():
     bucket_name = _create_objects(keys=['foo/bar', 'foo/bar/xyzzy', 'quux/thud', 'asdf'])
     client = get_client()
@@ -226,6 +230,7 @@ def test_bucket_list_delimiter_basic():
 @attr(operation='list')
 @attr(assertion='prefixes in multi-component object names')
 @attr('list-objects-v2')
+@attr('fails_on_dbstore')
 def test_bucket_listv2_delimiter_basic():
     bucket_name = _create_objects(keys=['foo/bar', 'foo/bar/xyzzy', 'quux/thud', 'asdf'])
     client = get_client()
@@ -246,6 +251,7 @@ def test_bucket_listv2_delimiter_basic():
 @attr(operation='list')
 @attr(assertion='test url encoding')
 @attr('list-objects-v2')
+@attr('fails_on_dbstore')
 def test_bucket_listv2_encoding_basic():
     bucket_name = _create_objects(keys=['foo+1/bar', 'foo/bar/xyzzy', 'quux ab/thud', 'asdf+b'])
     client = get_client()
@@ -264,6 +270,7 @@ def test_bucket_listv2_encoding_basic():
 @attr(operation='list')
 @attr(assertion='test url encoding')
 @attr('list-objects')
+@attr('fails_on_dbstore')
 def test_bucket_list_encoding_basic():
     bucket_name = _create_objects(keys=['foo+1/bar', 'foo/bar/xyzzy', 'quux ab/thud', 'asdf+b'])
     client = get_client()
@@ -329,6 +336,7 @@ def validate_bucket_listv2(bucket_name, prefix, delimiter, continuation_token, m
 @attr(method='get')
 @attr(operation='list')
 @attr(assertion='prefixes in multi-component object names')
+@attr('fails_on_dbstore')
 def test_bucket_list_delimiter_prefix():
     bucket_name = _create_objects(keys=['asdf', 'boo/bar', 'boo/baz/xyzzy', 'cquux/thud', 'cquux/bla'])
 
@@ -355,6 +363,7 @@ def test_bucket_list_delimiter_prefix():
 @attr(operation='list')
 @attr(assertion='prefixes in multi-component object names')
 @attr('list-objects-v2')
+@attr('fails_on_dbstore')
 def test_bucket_listv2_delimiter_prefix():
     bucket_name = _create_objects(keys=['asdf', 'boo/bar', 'boo/baz/xyzzy', 'cquux/thud', 'cquux/bla'])
 
@@ -390,6 +399,7 @@ def test_bucket_listv2_delimiter_prefix_ends_with_delimiter():
 @attr(method='get')
 @attr(operation='list')
 @attr(assertion='prefix and delimiter handling when object ends with delimiter')
+@attr('fails_on_dbstore')
 def test_bucket_list_delimiter_prefix_ends_with_delimiter():
     bucket_name = _create_objects(keys=['asdf/'])
     validate_bucket_list(bucket_name, 'asdf/', '/', '', 1000, False, ['asdf/'], [], None)
@@ -398,6 +408,7 @@ def test_bucket_list_delimiter_prefix_ends_with_delimiter():
 @attr(method='get')
 @attr(operation='list')
 @attr(assertion='non-slash delimiter characters')
+@attr('fails_on_dbstore')
 def test_bucket_list_delimiter_alt():
     bucket_name = _create_objects(keys=['bar', 'baz', 'cab', 'foo'])
     client = get_client()
@@ -418,6 +429,7 @@ def test_bucket_list_delimiter_alt():
 @attr(method='get')
 @attr(assertion='non-slash delimiter characters')
 @attr('list-objects-v2')
+@attr('fails_on_dbstore')
 def test_bucket_listv2_delimiter_alt():
     bucket_name = _create_objects(keys=['bar', 'baz', 'cab', 'foo'])
     client = get_client()
@@ -438,6 +450,7 @@ def test_bucket_listv2_delimiter_alt():
 @attr(method='get')
 @attr(operation='list')
 @attr(assertion='prefixes starting with underscore')
+@attr('fails_on_dbstore')
 def test_bucket_list_delimiter_prefix_underscore():
     bucket_name = _create_objects(keys=['_obj1_','_under1/bar', '_under1/baz/xyzzy', '_under2/thud', '_under2/bla'])
 
@@ -463,6 +476,7 @@ def test_bucket_list_delimiter_prefix_underscore():
 @attr(operation='list')
 @attr(assertion='prefixes starting with underscore')
 @attr('list-objects-v2')
+@attr('fails_on_dbstore')
 def test_bucket_listv2_delimiter_prefix_underscore():
     bucket_name = _create_objects(keys=['_obj1_','_under1/bar', '_under1/baz/xyzzy', '_under2/thud', '_under2/bla'])
 
@@ -488,6 +502,7 @@ def test_bucket_listv2_delimiter_prefix_underscore():
 @attr(method='get')
 @attr(operation='list')
 @attr(assertion='percentage delimiter characters')
+@attr('fails_on_dbstore')
 def test_bucket_list_delimiter_percentage():
     bucket_name = _create_objects(keys=['b%ar', 'b%az', 'c%ab', 'foo'])
     client = get_client()
@@ -507,6 +522,7 @@ def test_bucket_list_delimiter_percentage():
 @attr(method='get')
 @attr(assertion='percentage delimiter characters')
 @attr('list-objects-v2')
+@attr('fails_on_dbstore')
 def test_bucket_listv2_delimiter_percentage():
     bucket_name = _create_objects(keys=['b%ar', 'b%az', 'c%ab', 'foo'])
     client = get_client()
@@ -526,6 +542,7 @@ def test_bucket_listv2_delimiter_percentage():
 @attr(method='get')
 @attr(operation='list')
 @attr(assertion='whitespace delimiter characters')
+@attr('fails_on_dbstore')
 def test_bucket_list_delimiter_whitespace():
     bucket_name = _create_objects(keys=['b ar', 'b az', 'c ab', 'foo'])
     client = get_client()
@@ -545,6 +562,7 @@ def test_bucket_list_delimiter_whitespace():
 @attr(method='get')
 @attr(assertion='whitespace delimiter characters')
 @attr('list-objects-v2')
+@attr('fails_on_dbstore')
 def test_bucket_listv2_delimiter_whitespace():
     bucket_name = _create_objects(keys=['b ar', 'b az', 'c ab', 'foo'])
     client = get_client()
@@ -564,6 +582,7 @@ def test_bucket_listv2_delimiter_whitespace():
 @attr(method='get')
 @attr(operation='list')
 @attr(assertion='dot delimiter characters')
+@attr('fails_on_dbstore')
 def test_bucket_list_delimiter_dot():
     bucket_name = _create_objects(keys=['b.ar', 'b.az', 'c.ab', 'foo'])
     client = get_client()
@@ -583,6 +602,7 @@ def test_bucket_list_delimiter_dot():
 @attr(method='get')
 @attr(assertion='dot delimiter characters')
 @attr('list-objects-v2')
+@attr('fails_on_dbstore')
 def test_bucket_listv2_delimiter_dot():
     bucket_name = _create_objects(keys=['b.ar', 'b.az', 'c.ab', 'foo'])
     client = get_client()
@@ -778,6 +798,7 @@ def test_bucket_listv2_delimiter_not_exist():
 @attr(method='get')
 @attr(operation='list')
 @attr(assertion='list with delimiter not skip special keys')
+@attr('fails_on_dbstore')
 def test_bucket_list_delimiter_not_skip_special():
     key_names = ['0/'] + ['0/%s' % i for i in range(1000, 1999)]
     key_names2 = ['1999', '1999#', '1999+', '2000']
@@ -797,6 +818,7 @@ def test_bucket_list_delimiter_not_skip_special():
 @attr(method='get')
 @attr(operation='list under prefix')
 @attr(assertion='returns only objects under prefix')
+@attr('fails_on_dbstore')
 def test_bucket_list_prefix_basic():
     key_names = ['foo/bar', 'foo/baz', 'quux']
     bucket_name = _create_objects(keys=key_names)
@@ -815,6 +837,7 @@ def test_bucket_list_prefix_basic():
 @attr(operation='list under prefix with list-objects-v2')
 @attr(assertion='returns only objects under prefix')
 @attr('list-objects-v2')
+@attr('fails_on_dbstore')
 def test_bucket_listv2_prefix_basic():
     key_names = ['foo/bar', 'foo/baz', 'quux']
     bucket_name = _create_objects(keys=key_names)
@@ -833,6 +856,7 @@ def test_bucket_listv2_prefix_basic():
 @attr(method='get')
 @attr(operation='list under prefix')
 @attr(assertion='prefixes w/o delimiters')
+@attr('fails_on_dbstore')
 def test_bucket_list_prefix_alt():
     key_names = ['bar', 'baz', 'foo']
     bucket_name = _create_objects(keys=key_names)
@@ -851,6 +875,7 @@ def test_bucket_list_prefix_alt():
 @attr(operation='list under prefix with list-objects-v2')
 @attr(assertion='prefixes w/o delimiters')
 @attr('list-objects-v2')
+@attr('fails_on_dbstore')
 def test_bucket_listv2_prefix_alt():
     key_names = ['bar', 'baz', 'foo']
     bucket_name = _create_objects(keys=key_names)
@@ -938,6 +963,7 @@ def test_bucket_listv2_prefix_none():
 @attr(method='get')
 @attr(operation='list under prefix')
 @attr(assertion='nonexistent prefix returns nothing')
+@attr('fails_on_dbstore')
 def test_bucket_list_prefix_not_exist():
     key_names = ['foo/bar', 'foo/baz', 'quux']
     bucket_name = _create_objects(keys=key_names)
@@ -956,6 +982,7 @@ def test_bucket_list_prefix_not_exist():
 @attr(operation='list under prefix with list-objects-v2')
 @attr(assertion='nonexistent prefix returns nothing')
 @attr('list-objects-v2')
+@attr('fails_on_dbstore')
 def test_bucket_listv2_prefix_not_exist():
     key_names = ['foo/bar', 'foo/baz', 'quux']
     bucket_name = _create_objects(keys=key_names)
@@ -973,6 +1000,7 @@ def test_bucket_listv2_prefix_not_exist():
 @attr(method='get')
 @attr(operation='list under prefix')
 @attr(assertion='non-printable prefix can be specified')
+@attr('fails_on_dbstore')
 def test_bucket_list_prefix_unreadable():
     key_names = ['foo/bar', 'foo/baz', 'quux']
     bucket_name = _create_objects(keys=key_names)
@@ -991,6 +1019,7 @@ def test_bucket_list_prefix_unreadable():
 @attr(operation='list under prefix with list-objects-v2')
 @attr(assertion='non-printable prefix can be specified')
 @attr('list-objects-v2')
+@attr('fails_on_dbstore')
 def test_bucket_listv2_prefix_unreadable():
     key_names = ['foo/bar', 'foo/baz', 'quux']
     bucket_name = _create_objects(keys=key_names)
@@ -1008,6 +1037,7 @@ def test_bucket_listv2_prefix_unreadable():
 @attr(method='get')
 @attr(operation='list under prefix w/delimiter')
 @attr(assertion='returns only objects directly under prefix')
+@attr('fails_on_dbstore')
 def test_bucket_list_prefix_delimiter_basic():
     key_names = ['foo/bar', 'foo/baz/xyzzy', 'quux/thud', 'asdf']
     bucket_name = _create_objects(keys=key_names)
@@ -1027,6 +1057,7 @@ def test_bucket_list_prefix_delimiter_basic():
 @attr(operation='list-objects-v2 under prefix w/delimiter')
 @attr(assertion='returns only objects directly under prefix')
 @attr('list-objects-v2')
+@attr('fails_on_dbstore')
 def test_bucket_listv2_prefix_delimiter_basic():
     key_names = ['foo/bar', 'foo/baz/xyzzy', 'quux/thud', 'asdf']
     bucket_name = _create_objects(keys=key_names)
@@ -1045,6 +1076,7 @@ def test_bucket_listv2_prefix_delimiter_basic():
 @attr(method='get')
 @attr(operation='list under prefix w/delimiter')
 @attr(assertion='non-slash delimiters')
+@attr('fails_on_dbstore')
 def test_bucket_list_prefix_delimiter_alt():
     key_names = ['bar', 'bazar', 'cab', 'foo']
     bucket_name = _create_objects(keys=key_names)
@@ -1060,6 +1092,7 @@ def test_bucket_list_prefix_delimiter_alt():
     eq(prefixes, ['baza'])
 
 @attr('list-objects-v2')
+@attr('fails_on_dbstore')
 def test_bucket_listv2_prefix_delimiter_alt():
     key_names = ['bar', 'bazar', 'cab', 'foo']
     bucket_name = _create_objects(keys=key_names)
@@ -1078,6 +1111,7 @@ def test_bucket_listv2_prefix_delimiter_alt():
 @attr(method='get')
 @attr(operation='list under prefix w/delimiter')
 @attr(assertion='finds nothing w/unmatched prefix')
+@attr('fails_on_dbstore')
 def test_bucket_list_prefix_delimiter_prefix_not_exist():
     key_names = ['b/a/r', 'b/a/c', 'b/a/g', 'g']
     bucket_name = _create_objects(keys=key_names)
@@ -1095,6 +1129,7 @@ def test_bucket_list_prefix_delimiter_prefix_not_exist():
 @attr(operation='list-objects-v2 under prefix w/delimiter')
 @attr(assertion='finds nothing w/unmatched prefix')
 @attr('list-objects-v2')
+@attr('fails_on_dbstore')
 def test_bucket_listv2_prefix_delimiter_prefix_not_exist():
     key_names = ['b/a/r', 'b/a/c', 'b/a/g', 'g']
     bucket_name = _create_objects(keys=key_names)
@@ -1111,6 +1146,7 @@ def test_bucket_listv2_prefix_delimiter_prefix_not_exist():
 @attr(method='get')
 @attr(operation='list under prefix w/delimiter')
 @attr(assertion='over-ridden slash ceases to be a delimiter')
+@attr('fails_on_dbstore')
 def test_bucket_list_prefix_delimiter_delimiter_not_exist():
     key_names = ['b/a/c', 'b/a/g', 'b/a/r', 'g']
     bucket_name = _create_objects(keys=key_names)
@@ -1128,6 +1164,7 @@ def test_bucket_list_prefix_delimiter_delimiter_not_exist():
 @attr(operation='list-objects-v2 under prefix w/delimiter')
 @attr(assertion='over-ridden slash ceases to be a delimiter')
 @attr('list-objects-v2')
+@attr('fails_on_dbstore')
 def test_bucket_listv2_prefix_delimiter_delimiter_not_exist():
     key_names = ['b/a/c', 'b/a/g', 'b/a/r', 'g']
     bucket_name = _create_objects(keys=key_names)
@@ -1144,6 +1181,7 @@ def test_bucket_listv2_prefix_delimiter_delimiter_not_exist():
 @attr(method='get')
 @attr(operation='list under prefix w/delimiter')
 @attr(assertion='finds nothing w/unmatched prefix and delimiter')
+@attr('fails_on_dbstore')
 def test_bucket_list_prefix_delimiter_prefix_delimiter_not_exist():
     key_names = ['b/a/c', 'b/a/g', 'b/a/r', 'g']
     bucket_name = _create_objects(keys=key_names)
@@ -1161,6 +1199,7 @@ def test_bucket_list_prefix_delimiter_prefix_delimiter_not_exist():
 @attr(operation='list-objects-v2 under prefix w/delimiter')
 @attr(assertion='finds nothing w/unmatched prefix and delimiter')
 @attr('list-objects-v2')
+@attr('fails_on_dbstore')
 def test_bucket_listv2_prefix_delimiter_prefix_delimiter_not_exist():
     key_names = ['b/a/c', 'b/a/g', 'b/a/r', 'g']
     bucket_name = _create_objects(keys=key_names)
@@ -1177,6 +1216,7 @@ def test_bucket_listv2_prefix_delimiter_prefix_delimiter_not_exist():
 @attr(method='get')
 @attr(operation='list all keys')
 @attr(assertion='pagination w/max_keys=1, marker')
+@attr('fails_on_dbstore')
 def test_bucket_list_maxkeys_one():
     key_names = ['bar', 'baz', 'foo', 'quxx']
     bucket_name = _create_objects(keys=key_names)
@@ -1199,6 +1239,7 @@ def test_bucket_list_maxkeys_one():
 @attr(operation='list all keys with list-objects-v2')
 @attr(assertion='pagination w/max_keys=1, marker')
 @attr('list-objects-v2')
+@attr('fails_on_dbstore')
 def test_bucket_listv2_maxkeys_one():
     key_names = ['bar', 'baz', 'foo', 'quxx']
     bucket_name = _create_objects(keys=key_names)
@@ -1324,6 +1365,7 @@ def test_account_usage():
 @attr(operation='get usage by client')
 @attr(assertion='account usage by head bucket')
 @attr('fails_on_aws') # allow-unordered is a non-standard extension
+@attr('fails_on_dbstore')
 def test_head_bucket_usage():
     # boto3.set_stream_logger(name='botocore')
     client = get_client()
@@ -1345,6 +1387,7 @@ def test_head_bucket_usage():
 @attr(operation='list all keys')
 @attr(assertion='bucket list unordered')
 @attr('fails_on_aws') # allow-unordered is a non-standard extension
+@attr('fails_on_dbstore')
 def test_bucket_list_unordered():
     # boto3.set_stream_logger(name='botocore')
     keys_in = ['ado', 'bot', 'cob', 'dog', 'emu', 'fez', 'gnu', 'hex',
@@ -1402,6 +1445,7 @@ def test_bucket_list_unordered():
 @attr(assertion='bucket list unordered')
 @attr('fails_on_aws') # allow-unordered is a non-standard extension
 @attr('list-objects-v2')
+@attr('fails_on_dbstore')
 def test_bucket_listv2_unordered():
     # boto3.set_stream_logger(name='botocore')
     keys_in = ['ado', 'bot', 'cob', 'dog', 'emu', 'fez', 'gnu', 'hex',
@@ -1525,6 +1569,7 @@ def test_bucket_listv2_continuationtoken_empty():
 @attr(operation='list keys with list-objects-v2')
 @attr(assertion='no pagination, non-empty continuationtoken')
 @attr('list-objects-v2')
+@attr('fails_on_dbstore')
 def test_bucket_listv2_continuationtoken():
     key_names = ['bar', 'baz', 'foo', 'quxx']
     bucket_name = _create_objects(keys=key_names)
@@ -1545,6 +1590,7 @@ def test_bucket_listv2_continuationtoken():
 @attr(operation='list keys with list-objects-v2')
 @attr(assertion='no pagination, non-empty continuationtoken and startafter')
 @attr('list-objects-v2')
+@attr('fails_on_dbstore')
 def test_bucket_listv2_both_continuationtoken_startafter():
     key_names = ['bar', 'baz', 'foo', 'quxx']
     bucket_name = _create_objects(keys=key_names)
@@ -1665,6 +1711,7 @@ def _compare_dates(datetime1, datetime2):
 @attr(method='head')
 @attr(operation='compare w/bucket list')
 @attr(assertion='return same metadata')
+@attr('fails_on_dbstore')
 def test_bucket_list_return_data():
     key_names = ['bar', 'baz', 'foo']
     bucket_name = _create_objects(keys=key_names)
@@ -1723,6 +1770,7 @@ def check_configure_versioning_retry(bucket_name, status, expected_string):
 @attr(operation='compare w/bucket list when bucket versioning is configured')
 @attr(assertion='return same metadata')
 @attr('versioning')
+@attr('fails_on_dbstore')
 def test_bucket_list_return_data_versioning():
     bucket_name = get_new_bucket()
     check_configure_versioning_retry(bucket_name, "Enabled", "Enabled")
@@ -1964,6 +2012,7 @@ def get_http_response(**kwargs):
 @attr(method='get')
 @attr(operation='read contents that were never written to raise one error response')
 @attr(assertion='RequestId appears in the error response')
+@attr('fails_on_dbstore')
 def test_object_requestid_matches_header_on_error():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -2042,6 +2091,7 @@ def test_multi_objectv2_delete():
 @attr(method='post')
 @attr(operation='delete multiple objects has upper limit of 1000 keys')
 @attr(assertion='fails 400')
+@attr('fails_on_dbstore')
 def test_multi_object_delete_key_limit():
     key_names = [f"key-{i}" for i in range(1001)]
     bucket_name = _create_objects(keys=key_names)
@@ -2063,6 +2113,7 @@ def test_multi_object_delete_key_limit():
 @attr(method='post')
 @attr(operation='delete multiple objects has upper limit of 1000 keys with list-objects-v2')
 @attr(assertion='fails 400')
+@attr('fails_on_dbstore')
 def test_multi_objectv2_delete_key_limit():
     key_names = [f"key-{i}" for i in range(1001)]
     bucket_name = _create_objects(keys=key_names)
@@ -3517,6 +3568,7 @@ def test_get_object_ifmodifiedsince_good():
 @attr(method='get')
 @attr(operation='get w/ If-Modified-Since: after')
 @attr(assertion='fails 304')
+@attr('fails_on_dbstore')
 def test_get_object_ifmodifiedsince_failed():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -3541,6 +3593,7 @@ def test_get_object_ifmodifiedsince_failed():
 @attr(method='get')
 @attr(operation='get w/ If-Unmodified-Since: before')
 @attr(assertion='fails 412')
+@attr('fails_on_dbstore')
 def test_get_object_ifunmodifiedsince_good():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -3594,6 +3647,7 @@ def test_put_object_ifmatch_good():
 @attr(method='get')
 @attr(operation='get w/ If-Match: bogus ETag')
 @attr(assertion='fails 412')
+@attr('fails_on_dbstore')
 def test_put_object_ifmatch_failed():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -3641,6 +3695,7 @@ def test_put_object_ifmatch_overwrite_existed_good():
 @attr(operation='overwrite non-existing object w/ If-Match: *')
 @attr(assertion='fails 412')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_put_object_ifmatch_nonexisted_failed():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -3683,6 +3738,7 @@ def test_put_object_ifnonmatch_good():
 @attr(operation='overwrite existing object w/ If-None-Match: the latest ETag')
 @attr(assertion='fails 412')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_put_object_ifnonmatch_failed():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -3728,6 +3784,7 @@ def test_put_object_ifnonmatch_nonexisted_good():
 @attr(operation='overwrite existing object w/ If-None-Match: *')
 @attr(assertion='fails 412')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_put_object_ifnonmatch_overwrite_existed_failed():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -3868,6 +3925,7 @@ def test_bucket_head_notexist():
 @attr(method='head')
 @attr(operation='read bucket extended information')
 @attr(assertion='extended information is getting updated')
+@attr('fails_on_dbstore')
 def test_bucket_head_extended():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -4435,6 +4493,7 @@ def test_bucket_create_exists():
 @attr(resource='bucket')
 @attr(method='get')
 @attr(operation='get location')
+@attr('fails_on_dbstore')
 def test_bucket_get_location():
     location_constraint = get_main_api_name()
     if not location_constraint:
@@ -4453,6 +4512,7 @@ def test_bucket_get_location():
 @attr(method='put')
 @attr(operation='re-create by non-owner')
 @attr(assertion='fails 409')
+@attr('fails_on_dbstore')
 def test_bucket_create_exists_nonowner():
     # Names are shared across a global namespace. As such, no two
     # users can create a bucket with that same name.
@@ -4471,6 +4531,7 @@ def test_bucket_create_exists_nonowner():
 @attr(method='put')
 @attr(operation='re-create with existing acl')
 @attr(assertion='fails 409')
+@attr('fails_on_dbstore')
 def test_bucket_recreate_overwrite_acl():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -4485,6 +4546,7 @@ def test_bucket_recreate_overwrite_acl():
 @attr(method='put')
 @attr(operation='re-create with new acl')
 @attr(assertion='fails 409')
+@attr('fails_on_dbstore')
 def test_bucket_recreate_new_acl():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -4937,6 +4999,7 @@ def test_object_acl_canned_authenticatedread():
 @attr(method='put')
 @attr(operation='acl bucket-owner-read')
 @attr(assertion='read back expected values')
+@attr('fails_on_dbstore')
 def test_object_acl_canned_bucketownerread():
     bucket_name = get_new_bucket_name()
     main_client = get_client()
@@ -4983,6 +5046,7 @@ def test_object_acl_canned_bucketownerread():
 @attr(method='put')
 @attr(operation='acl bucket-owner-read')
 @attr(assertion='read back expected values')
+@attr('fails_on_dbstore')
 def test_object_acl_canned_bucketownerfullcontrol():
     bucket_name = get_new_bucket_name()
     main_client = get_client()
@@ -5365,6 +5429,7 @@ def test_bucket_acl_grant_userid_fullcontrol():
 @attr(operation='set acl w/userid READ')
 @attr(assertion='can read data, no other r/w')
 @attr('fails_on_aws') #  <Error><Code>InvalidArgument</Code><Message>Invalid id</Message><ArgumentName>CanonicalUser/ID</ArgumentName><ArgumentValue>${ALTUSER}</ArgumentValue>
+@attr('fails_on_dbstore')
 def test_bucket_acl_grant_userid_read():
     bucket_name = _bucket_acl_grant_userid('READ')
 
@@ -5382,6 +5447,7 @@ def test_bucket_acl_grant_userid_read():
 @attr(operation='set acl w/userid READ_ACP')
 @attr(assertion='can read acl, no other r/w')
 @attr('fails_on_aws') #  <Error><Code>InvalidArgument</Code><Message>Invalid id</Message><ArgumentName>CanonicalUser/ID</ArgumentName><ArgumentValue>${ALTUSER}</ArgumentValue>
+@attr('fails_on_dbstore')
 def test_bucket_acl_grant_userid_readacp():
     bucket_name = _bucket_acl_grant_userid('READ_ACP')
 
@@ -5400,6 +5466,7 @@ def test_bucket_acl_grant_userid_readacp():
 @attr(operation='set acl w/userid WRITE')
 @attr(assertion='can write data, no other r/w')
 @attr('fails_on_aws') #  <Error><Code>InvalidArgument</Code><Message>Invalid id</Message><ArgumentName>CanonicalUser/ID</ArgumentName><ArgumentValue>${ALTUSER}</ArgumentValue>
+@attr('fails_on_dbstore')
 def test_bucket_acl_grant_userid_write():
     bucket_name = _bucket_acl_grant_userid('WRITE')
 
@@ -5417,6 +5484,7 @@ def test_bucket_acl_grant_userid_write():
 @attr(operation='set acl w/userid WRITE_ACP')
 @attr(assertion='can write acls, no other r/w')
 @attr('fails_on_aws') #  <Error><Code>InvalidArgument</Code><Message>Invalid id</Message><ArgumentName>CanonicalUser/ID</ArgumentName><ArgumentValue>${ALTUSER}</ArgumentValue>
+@attr('fails_on_dbstore')
 def test_bucket_acl_grant_userid_writeacp():
     bucket_name = _bucket_acl_grant_userid('WRITE_ACP')
 
@@ -5828,6 +5896,7 @@ def list_bucket_versions(client, bucket_name):
 @attr(method='ACLs')
 @attr(operation='set bucket/object acls: private/private')
 @attr(assertion='public has no access to bucket or objects')
+@attr('fails_on_dbstore')
 def test_access_bucket_private_object_private():
     # all the test_access_* tests follow this template
     bucket_name, key1, key2, newkey = _setup_access(bucket_acl='private', object_acl='private')
@@ -5860,6 +5929,7 @@ def test_access_bucket_private_object_private():
 @attr(operation='set bucket/object acls: private/private with list-objects-v2')
 @attr(assertion='public has no access to bucket or objects')
 @attr('list-objects-v2')
+@attr('fails_on_dbstore')
 def test_access_bucket_private_objectv2_private():
     # all the test_access_* tests follow this template
     bucket_name, key1, key2, newkey = _setup_access(bucket_acl='private', object_acl='private')
@@ -5891,6 +5961,7 @@ def test_access_bucket_private_objectv2_private():
 @attr(method='ACLs')
 @attr(operation='set bucket/object acls: private/public-read')
 @attr(assertion='public can only read readable object')
+@attr('fails_on_dbstore')
 def test_access_bucket_private_object_publicread():
 
     bucket_name, key1, key2, newkey = _setup_access(bucket_acl='private', object_acl='public-read')
@@ -5916,6 +5987,7 @@ def test_access_bucket_private_object_publicread():
 @attr(operation='set bucket/object acls: private/public-read with list-objects-v2')
 @attr(assertion='public can only read readable object')
 @attr('list-objects-v2')
+@attr('fails_on_dbstore')
 def test_access_bucket_private_objectv2_publicread():
 
     bucket_name, key1, key2, newkey = _setup_access(bucket_acl='private', object_acl='public-read')
@@ -5940,6 +6012,7 @@ def test_access_bucket_private_objectv2_publicread():
 @attr(method='ACLs')
 @attr(operation='set bucket/object acls: private/public-read/write')
 @attr(assertion='public can only read the readable object')
+@attr('fails_on_dbstore')
 def test_access_bucket_private_object_publicreadwrite():
     bucket_name, key1, key2, newkey = _setup_access(bucket_acl='private', object_acl='public-read-write')
     alt_client = get_alt_client()
@@ -5965,6 +6038,7 @@ def test_access_bucket_private_object_publicreadwrite():
 @attr(operation='set bucket/object acls: private/public-read/write with list-objects-v2')
 @attr(assertion='public can only read the readable object')
 @attr('list-objects-v2')
+@attr('fails_on_dbstore')
 def test_access_bucket_private_objectv2_publicreadwrite():
     bucket_name, key1, key2, newkey = _setup_access(bucket_acl='private', object_acl='public-read-write')
     alt_client = get_alt_client()
@@ -5989,6 +6063,7 @@ def test_access_bucket_private_objectv2_publicreadwrite():
 @attr(method='ACLs')
 @attr(operation='set bucket/object acls: public-read/private')
 @attr(assertion='public can only list the bucket')
+@attr('fails_on_dbstore')
 def test_access_bucket_publicread_object_private():
     bucket_name, key1, key2, newkey = _setup_access(bucket_acl='public-read', object_acl='private')
     alt_client = get_alt_client()
@@ -6012,6 +6087,7 @@ def test_access_bucket_publicread_object_private():
 @attr(method='ACLs')
 @attr(operation='set bucket/object acls: public-read/public-read')
 @attr(assertion='public can read readable objects and list bucket')
+@attr('fails_on_dbstore')
 def test_access_bucket_publicread_object_publicread():
     bucket_name, key1, key2, newkey = _setup_access(bucket_acl='public-read', object_acl='public-read')
     alt_client = get_alt_client()
@@ -6040,6 +6116,7 @@ def test_access_bucket_publicread_object_publicread():
 @attr(method='ACLs')
 @attr(operation='set bucket/object acls: public-read/public-read-write')
 @attr(assertion='public can read readable objects and list bucket')
+@attr('fails_on_dbstore')
 def test_access_bucket_publicread_object_publicreadwrite():
     bucket_name, key1, key2, newkey = _setup_access(bucket_acl='public-read', object_acl='public-read-write')
     alt_client = get_alt_client()
@@ -6070,6 +6147,7 @@ def test_access_bucket_publicread_object_publicreadwrite():
 @attr(method='ACLs')
 @attr(operation='set bucket/object acls: public-read-write/private')
 @attr(assertion='private objects cannot be read, but can be overwritten')
+@attr('fails_on_dbstore')
 def test_access_bucket_publicreadwrite_object_private():
     bucket_name, key1, key2, newkey = _setup_access(bucket_acl='public-read-write', object_acl='private')
     alt_client = get_alt_client()
@@ -6089,6 +6167,7 @@ def test_access_bucket_publicreadwrite_object_private():
 @attr(method='ACLs')
 @attr(operation='set bucket/object acls: public-read-write/public-read')
 @attr(assertion='private objects cannot be read, but can be overwritten')
+@attr('fails_on_dbstore')
 def test_access_bucket_publicreadwrite_object_publicread():
     bucket_name, key1, key2, newkey = _setup_access(bucket_acl='public-read-write', object_acl='public-read')
     alt_client = get_alt_client()
@@ -6111,6 +6190,7 @@ def test_access_bucket_publicreadwrite_object_publicread():
 @attr(method='ACLs')
 @attr(operation='set bucket/object acls: public-read-write/public-read-write')
 @attr(assertion='private objects cannot be read, but can be overwritten')
+@attr('fails_on_dbstore')
 def test_access_bucket_publicreadwrite_object_publicreadwrite():
     bucket_name, key1, key2, newkey = _setup_access(bucket_acl='public-read-write', object_acl='public-read-write')
     alt_client = get_alt_client()
@@ -6186,6 +6266,7 @@ def test_list_buckets_anonymous():
 @attr(method='get')
 @attr(operation='list all buckets (bad auth)')
 @attr(assertion='fails 403')
+@attr('fails_on_dbstore')
 def test_list_buckets_invalid_auth():
     bad_auth_client = get_bad_auth_client()
     e = assert_raises(ClientError, bad_auth_client.list_buckets)
@@ -6266,6 +6347,7 @@ def test_bucket_recreate_not_overriding():
 @attr(method='put')
 @attr(operation='create and list objects with special names')
 @attr(assertion='special names work')
+@attr('fails_on_dbstore')
 def test_bucket_create_special_key_names():
     key_names = [
         ' ',
@@ -6300,6 +6382,7 @@ def test_bucket_create_special_key_names():
 @attr(method='get')
 @attr(operation='create and list objects with underscore as prefix, list using prefix')
 @attr(assertion='listing works correctly')
+@attr('fails_on_dbstore')
 def test_bucket_list_special_prefix():
     key_names = ['_bla/1', '_bla/2', '_bla/3', '_bla/4', 'abcd']
     bucket_name = _create_objects(keys=key_names)
@@ -6315,6 +6398,7 @@ def test_bucket_list_special_prefix():
 @attr(method='put')
 @attr(operation='copy zero sized object in same bucket')
 @attr(assertion='works')
+@attr('fails_on_dbstore')
 def test_object_copy_zero_size():
     key = 'foo123bar'
     bucket_name = _create_objects(keys=[key])
@@ -6332,6 +6416,7 @@ def test_object_copy_zero_size():
 @attr(method='put')
 @attr(operation='copy object in same bucket')
 @attr(assertion='works')
+@attr('fails_on_dbstore')
 def test_object_copy_same_bucket():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -6349,6 +6434,7 @@ def test_object_copy_same_bucket():
 @attr(method='put')
 @attr(operation='copy object with content-type')
 @attr(assertion='works')
+@attr('fails_on_dbstore')
 def test_object_copy_verify_contenttype():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -6370,6 +6456,7 @@ def test_object_copy_verify_contenttype():
 @attr(method='put')
 @attr(operation='copy object to itself')
 @attr(assertion='fails')
+@attr('fails_on_dbstore')
 def test_object_copy_to_itself():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -6386,6 +6473,7 @@ def test_object_copy_to_itself():
 @attr(method='put')
 @attr(operation='modify object metadata by copying')
 @attr(assertion='fails')
+@attr('fails_on_dbstore')
 def test_object_copy_to_itself_with_metadata():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -6401,6 +6489,7 @@ def test_object_copy_to_itself_with_metadata():
 @attr(method='put')
 @attr(operation='copy object from different bucket')
 @attr(assertion='works')
+@attr('fails_on_dbstore')
 def test_object_copy_diff_bucket():
     bucket_name1 = get_new_bucket()
     bucket_name2 = get_new_bucket()
@@ -6420,6 +6509,7 @@ def test_object_copy_diff_bucket():
 @attr(method='put')
 @attr(operation='copy to an inaccessible bucket')
 @attr(assertion='fails w/AttributeError')
+@attr('fails_on_dbstore')
 def test_object_copy_not_owned_bucket():
     client = get_client()
     alt_client = get_alt_client()
@@ -6440,6 +6530,7 @@ def test_object_copy_not_owned_bucket():
 @attr(method='put')
 @attr(operation='copy a non-owned object in a non-owned bucket, but with perms')
 @attr(assertion='works')
+@attr('fails_on_dbstore')
 def test_object_copy_not_owned_object_bucket():
     client = get_client()
     alt_client = get_alt_client()
@@ -6465,6 +6556,7 @@ def test_object_copy_not_owned_object_bucket():
 @attr(method='put')
 @attr(operation='copy object and change acl')
 @attr(assertion='works')
+@attr('fails_on_dbstore')
 def test_object_copy_canned_acl():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -6487,6 +6579,7 @@ def test_object_copy_canned_acl():
 @attr(resource='object')
 @attr(method='put')
 @attr(operation='copy object and retain metadata')
+@attr('fails_on_dbstore')
 def test_object_copy_retaining_metadata():
     for size in [3, 1024 * 1024]:
         bucket_name = get_new_bucket()
@@ -6508,6 +6601,7 @@ def test_object_copy_retaining_metadata():
 @attr(resource='object')
 @attr(method='put')
 @attr(operation='copy object and replace metadata')
+@attr('fails_on_dbstore')
 def test_object_copy_replacing_metadata():
     for size in [3, 1024 * 1024]:
         bucket_name = get_new_bucket()
@@ -6531,6 +6625,7 @@ def test_object_copy_replacing_metadata():
 @attr(resource='object')
 @attr(method='put')
 @attr(operation='copy from non-existent bucket')
+@attr('fails_on_dbstore')
 def test_object_copy_bucket_not_found():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -6543,6 +6638,7 @@ def test_object_copy_bucket_not_found():
 @attr(resource='object')
 @attr(method='put')
 @attr(operation='copy from non-existent object')
+@attr('fails_on_dbstore')
 def test_object_copy_key_not_found():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -6557,6 +6653,7 @@ def test_object_copy_key_not_found():
 @attr(operation='copy object to/from versioned bucket')
 @attr(assertion='works')
 @attr('versioning')
+@attr('fails_on_dbstore')
 def test_object_copy_versioned_bucket():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -6625,6 +6722,7 @@ def test_object_copy_versioned_bucket():
 @attr(operation='copy object to/from versioned bucket with url-encoded name')
 @attr(assertion='works')
 @attr('versioning')
+@attr('fails_on_dbstore')
 def test_object_copy_versioned_url_encoding():
     bucket = get_new_bucket_resource()
     check_configure_versioning_retry(bucket.name, "Enabled", "Enabled")
@@ -6692,6 +6790,7 @@ def _multipart_upload(bucket_name, key, size, part_size=5*1024*1024, client=None
 @attr(operation='test copy object of a multipart upload')
 @attr(assertion='successful')
 @attr('versioning')
+@attr('fails_on_dbstore')
 def test_object_copy_versioning_multipart_upload():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -6786,6 +6885,7 @@ def test_multipart_upload_empty():
 @attr(resource='object')
 @attr(method='put')
 @attr(operation='check multipart uploads with single small part')
+@attr('fails_on_dbstore')
 def test_multipart_upload_small():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -6863,6 +6963,7 @@ def _check_key_content(src_key, src_bucket_name, dest_key, dest_bucket_name, ver
 @attr(resource='object')
 @attr(method='put')
 @attr(operation='check multipart copies with single small part')
+@attr('fails_on_dbstore')
 def test_multipart_copy_small():
     src_key = 'foo'
     src_bucket_name = _create_key_with_random_content(src_key)
@@ -6966,6 +7067,7 @@ def test_multipart_copy_without_range():
 @attr(resource='object')
 @attr(method='put')
 @attr(operation='check multipart copies with single small part')
+@attr('fails_on_dbstore')
 def test_multipart_copy_special_names():
     src_bucket_name = get_new_bucket()
 
@@ -7004,6 +7106,7 @@ def _check_content_using_range(key, bucket_name, data, step):
 @attr(operation='complete multi-part upload')
 @attr(assertion='successful')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_multipart_upload():
     bucket_name = get_new_bucket()
     key="mymultipart"
@@ -7068,6 +7171,7 @@ def check_configure_versioning_retry(bucket_name, status, expected_string):
 @attr(method='put')
 @attr(operation='check multipart copies of versioned objects')
 @attr('versioning')
+@attr('fails_on_dbstore')
 def test_multipart_copy_versioned():
     src_bucket_name = get_new_bucket()
     dest_bucket_name = get_new_bucket()
@@ -7120,6 +7224,7 @@ def _check_upload_multipart_resend(bucket_name, key, objlen, resend_parts):
 @attr(method='put')
 @attr(operation='complete multi-part upload')
 @attr(assertion='successful')
+@attr('fails_on_dbstore')
 def test_multipart_upload_resend_part():
     bucket_name = get_new_bucket()
     key="mymultipart"
@@ -7162,6 +7267,7 @@ def test_multipart_upload_multiple_sizes():
     client.complete_multipart_upload(Bucket=bucket_name, Key=key, UploadId=upload_id, MultipartUpload={'Parts': parts})
 
 @attr(assertion='successful')
+@attr('fails_on_dbstore')
 def test_multipart_copy_multiple_sizes():
     src_key = 'foo'
     src_bucket_name = _create_key_with_random_content(src_key, 12*1024*1024)
@@ -7253,6 +7359,7 @@ def _do_test_multipart_upload_contents(bucket_name, key, num_parts):
 @attr(method='put')
 @attr(operation='check contents of multi-part upload')
 @attr(assertion='successful')
+@attr('fails_on_dbstore')
 def test_multipart_upload_contents():
     bucket_name = get_new_bucket()
     _do_test_multipart_upload_contents(bucket_name, 'mymultipart', 3)
@@ -7325,6 +7432,7 @@ def test_abort_multipart_upload_not_found():
 @attr(method='put')
 @attr(operation='concurrent multi-part uploads')
 @attr(assertion='successful')
+@attr('fails_on_dbstore')
 def test_list_multipart_upload():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -7359,6 +7467,7 @@ def test_list_multipart_upload():
 @attr(method='get')
 @attr(operation='list multipart uploads with different owners')
 @attr(assertion='successful')
+@attr('fails_on_dbstore')
 def test_list_multipart_upload_owner():
     bucket_name = get_new_bucket()
 
@@ -7897,6 +8006,7 @@ def _test_atomic_write(file_size):
 @attr(method='put')
 @attr(operation='write atomicity')
 @attr(assertion='1MB successful')
+@attr('fails_on_dbstore')
 def test_atomic_write_1mb():
     _test_atomic_write(1024*1024)
 
@@ -8167,6 +8277,7 @@ def test_multipart_resend_first_finishes_last():
 @attr(method='get')
 @attr(operation='range')
 @attr(assertion='returns correct data, 206')
+@attr('fails_on_dbstore')
 def test_ranged_request_response_code():
     content = 'testcontent'
 
@@ -8188,6 +8299,7 @@ def _generate_random_string(size):
 @attr(method='get')
 @attr(operation='range')
 @attr(assertion='returns correct data, 206')
+@attr('fails_on_dbstore')
 def test_ranged_big_request_response_code():
     content = _generate_random_string(8*1024*1024)
 
@@ -8206,6 +8318,7 @@ def test_ranged_big_request_response_code():
 @attr(method='get')
 @attr(operation='range')
 @attr(assertion='returns correct data, 206')
+@attr('fails_on_dbstore')
 def test_ranged_request_skip_leading_bytes_response_code():
     content = 'testcontent'
 
@@ -8224,6 +8337,7 @@ def test_ranged_request_skip_leading_bytes_response_code():
 @attr(method='get')
 @attr(operation='range')
 @attr(assertion='returns correct data, 206')
+@attr('fails_on_dbstore')
 def test_ranged_request_return_trailing_bytes_response_code():
     content = 'testcontent'
 
@@ -8279,6 +8393,7 @@ def test_ranged_request_empty_object():
 @attr(operation='create versioned bucket')
 @attr(assertion='can create and suspend bucket versioning')
 @attr('versioning')
+@attr('fails_on_dbstore')
 def test_versioning_bucket_create_suspend():
     bucket_name = get_new_bucket()
     check_versioning(bucket_name, None)
@@ -8367,6 +8482,7 @@ def _do_test_create_remove_versions(client, bucket_name, key, num_versions, remo
 @attr(operation='create and remove versioned object')
 @attr(assertion='can create access and remove appropriate versions')
 @attr('versioning')
+@attr('fails_on_dbstore')
 def test_versioning_obj_create_read_remove():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -8386,6 +8502,7 @@ def test_versioning_obj_create_read_remove():
 @attr(operation='create and remove versioned object and head')
 @attr(assertion='can create access and remove appropriate versions')
 @attr('versioning')
+@attr('fails_on_dbstore')
 def test_versioning_obj_create_read_remove_head():
     bucket_name = get_new_bucket()
 
@@ -8425,6 +8542,7 @@ def test_versioning_obj_create_read_remove_head():
 @attr(operation='create object, then switch to versioning')
 @attr(assertion='behaves correctly')
 @attr('versioning')
+@attr('fails_on_dbstore')
 def test_versioning_obj_plain_null_version_removal():
     bucket_name = get_new_bucket()
     check_versioning(bucket_name, None)
@@ -8450,6 +8568,7 @@ def test_versioning_obj_plain_null_version_removal():
 @attr(operation='create object, then switch to versioning')
 @attr(assertion='behaves correctly')
 @attr('versioning')
+@attr('fails_on_dbstore')
 def test_versioning_obj_plain_null_version_overwrite():
     bucket_name = get_new_bucket()
     check_versioning(bucket_name, None)
@@ -8488,6 +8607,7 @@ def test_versioning_obj_plain_null_version_overwrite():
 @attr(operation='create object, then switch to versioning')
 @attr(assertion='behaves correctly')
 @attr('versioning')
+@attr('fails_on_dbstore')
 def test_versioning_obj_plain_null_version_overwrite_suspended():
     bucket_name = get_new_bucket()
     check_versioning(bucket_name, None)
@@ -8558,6 +8678,7 @@ def overwrite_suspended_versioning_obj(client, bucket_name, key, version_ids, co
 @attr(operation='suspend versioned bucket')
 @attr(assertion='suspended versioning behaves correctly')
 @attr('versioning')
+@attr('fails_on_dbstore')
 def test_versioning_obj_suspend_versions():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -8595,6 +8716,7 @@ def test_versioning_obj_suspend_versions():
 @attr(operation='create and remove versions')
 @attr(assertion='everything works')
 @attr('versioning')
+@attr('fails_on_dbstore')
 def test_versioning_obj_create_versions_remove_all():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -8615,6 +8737,7 @@ def test_versioning_obj_create_versions_remove_all():
 @attr(method='remove')
 @attr(operation='create and remove versions')
 @attr(assertion='everything works')
+@attr('fails_on_dbstore')
 @attr('versioning')
 def test_versioning_obj_create_versions_remove_special_names():
     bucket_name = get_new_bucket()
@@ -8638,6 +8761,7 @@ def test_versioning_obj_create_versions_remove_special_names():
 @attr(operation='create and test multipart object')
 @attr(assertion='everything works')
 @attr('versioning')
+@attr('fails_on_dbstore')
 def test_versioning_obj_create_overwrite_multipart():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -8671,6 +8795,7 @@ def test_versioning_obj_create_overwrite_multipart():
 @attr(operation='list versioned objects')
 @attr(assertion='everything works')
 @attr('versioning')
+@attr('fails_on_dbstore')
 def test_versioning_obj_list_marker():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -8731,6 +8856,7 @@ def test_versioning_obj_list_marker():
 @attr(operation='create and test versioned object copying')
 @attr(assertion='everything works')
 @attr('versioning')
+@attr('fails_on_dbstore')
 def test_versioning_copy_obj_version():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -8773,6 +8899,7 @@ def test_versioning_copy_obj_version():
 @attr(operation='delete multiple versions')
 @attr(assertion='deletes multiple versions of an object with a single call')
 @attr('versioning')
+@attr('fails_on_dbstore')
 def test_versioning_multi_object_delete():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -8806,6 +8933,7 @@ def test_versioning_multi_object_delete():
 @attr(operation='delete multiple versions')
 @attr(assertion='deletes multiple versions of an object and delete marker with a single call')
 @attr('versioning')
+@attr('fails_on_dbstore')
 def test_versioning_multi_object_delete_with_marker():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -8852,6 +8980,7 @@ def test_versioning_multi_object_delete_with_marker():
 @attr(operation='multi delete create marker')
 @attr(assertion='returns correct marker version id')
 @attr('versioning')
+@attr('fails_on_dbstore')
 def test_versioning_multi_object_delete_with_marker_create():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -8875,6 +9004,7 @@ def test_versioning_multi_object_delete_with_marker_create():
 @attr(operation='change acl on an object version changes specific version')
 @attr(assertion='works')
 @attr('versioning')
+@attr('fails_on_dbstore')
 def test_versioned_object_acl():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -8947,6 +9077,7 @@ def test_versioned_object_acl():
 @attr(operation='change acl on an object with no version specified changes latest version')
 @attr(assertion='works')
 @attr('versioning')
+@attr('fails_on_dbstore')
 def test_versioned_object_acl_no_version_specified():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9073,6 +9204,7 @@ def test_versioned_concurrent_object_create_concurrent_remove():
 @attr(operation='concurrent creation and removal of objects')
 @attr(assertion='works')
 @attr('versioning')
+@attr('fails_on_dbstore')
 def test_versioned_concurrent_object_create_and_remove():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9105,6 +9237,7 @@ def test_versioned_concurrent_object_create_and_remove():
 @attr(method='put')
 @attr(operation='set lifecycle config')
 @attr('lifecycle')
+@attr('fails_on_dbstore')
 def test_lifecycle_set():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9118,6 +9251,7 @@ def test_lifecycle_set():
 @attr(method='get')
 @attr(operation='get lifecycle config')
 @attr('lifecycle')
+@attr('fails_on_dbstore')
 def test_lifecycle_get():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9132,6 +9266,7 @@ def test_lifecycle_get():
 @attr(method='get')
 @attr(operation='get lifecycle config no id')
 @attr('lifecycle')
+@attr('fails_on_dbstore')
 def test_lifecycle_get_no_id():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9168,6 +9303,7 @@ def test_lifecycle_get_no_id():
 @attr('lifecycle')
 @attr('lifecycle_expiration')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_lifecycle_expiration():
     bucket_name = _create_objects(keys=['expire1/foo', 'expire1/bar', 'keep2/foo',
                                         'keep2/bar', 'expire3/foo', 'expire3/bar'])
@@ -9205,6 +9341,7 @@ def test_lifecycle_expiration():
 @attr('lifecycle_expiration')
 @attr('fails_on_aws')
 @attr('list-objects-v2')
+@attr('fails_on_dbstore')
 def test_lifecyclev2_expiration():
     bucket_name = _create_objects(keys=['expire1/foo', 'expire1/bar', 'keep2/foo',
                                         'keep2/bar', 'expire3/foo', 'expire3/bar'])
@@ -9241,6 +9378,7 @@ def test_lifecyclev2_expiration():
 @attr('lifecycle')
 @attr('lifecycle_expiration')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_lifecycle_expiration_versioning_enabled():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9268,6 +9406,7 @@ def test_lifecycle_expiration_versioning_enabled():
 @attr('lifecycle')
 @attr('lifecycle_expiration')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_lifecycle_expiration_tags1():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9379,6 +9518,7 @@ def setup_lifecycle_tags2(client, bucket_name):
 @attr('lifecycle')
 @attr('lifecycle_expiration')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_lifecycle_expiration_tags2():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9399,6 +9539,7 @@ def test_lifecycle_expiration_tags2():
 @attr('lifecycle')
 @attr('lifecycle_expiration')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_lifecycle_expiration_versioned_tags2():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9471,6 +9612,7 @@ def verify_lifecycle_expiration_noncur_tags(client, bucket_name, secs):
 @attr('lifecycle')
 @attr('lifecycle_expiration')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_lifecycle_expiration_noncur_tags1():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9500,6 +9642,7 @@ def test_lifecycle_expiration_noncur_tags1():
 @attr(operation='id too long in lifecycle rule')
 @attr('lifecycle')
 @attr(assertion='fails 400')
+@attr('fails_on_dbstore')
 def test_lifecycle_id_too_long():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9516,6 +9659,7 @@ def test_lifecycle_id_too_long():
 @attr(operation='same id')
 @attr('lifecycle')
 @attr(assertion='fails 400')
+@attr('fails_on_dbstore')
 def test_lifecycle_same_id():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9533,6 +9677,7 @@ def test_lifecycle_same_id():
 @attr(operation='invalid status in lifecycle rule')
 @attr('lifecycle')
 @attr(assertion='fails 400')
+@attr('fails_on_dbstore')
 def test_lifecycle_invalid_status():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9564,6 +9709,7 @@ def test_lifecycle_invalid_status():
 @attr(method='put')
 @attr(operation='set lifecycle config with expiration date')
 @attr('lifecycle')
+@attr('fails_on_dbstore')
 def test_lifecycle_set_date():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9594,6 +9740,7 @@ def test_lifecycle_set_invalid_date():
 @attr('lifecycle')
 @attr('lifecycle_expiration')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_lifecycle_expiration_date():
     bucket_name = _create_objects(keys=['past/foo', 'future/bar'])
     client = get_client()
@@ -9619,6 +9766,7 @@ def test_lifecycle_expiration_date():
 @attr(operation='test lifecycle expiration days 0')
 @attr('lifecycle')
 @attr('lifecycle_expiration')
+@attr('fails_on_dbstore')
 def test_lifecycle_expiration_days0():
     bucket_name = _create_objects(keys=['days0/foo', 'days0/bar'])
     client = get_client()
@@ -9673,6 +9821,7 @@ def check_lifecycle_expiration_header(response, start_time, rule_id,
 @attr(operation='test lifecycle expiration header put')
 @attr('lifecycle')
 @attr('lifecycle_expiration')
+@attr('fails_on_dbstore')
 def test_lifecycle_expiration_header_put():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9687,6 +9836,7 @@ def test_lifecycle_expiration_header_put():
 @attr(operation='test lifecycle expiration header head')
 @attr('lifecycle')
 @attr('lifecycle_expiration')
+@attr('fails_on_dbstore')
 def test_lifecycle_expiration_header_head():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9707,6 +9857,7 @@ def test_lifecycle_expiration_header_head():
 @attr(operation='test lifecycle expiration header head with tags')
 @attr('lifecycle')
 @attr('lifecycle_expiration')
+@attr('fails_on_dbstore')
 def test_lifecycle_expiration_header_tags_head():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9765,6 +9916,7 @@ def test_lifecycle_expiration_header_tags_head():
 @attr(operation='test lifecycle expiration header head with tags and And')
 @attr('lifecycle')
 @attr('lifecycle_expiration')
+@attr('fails_on_dbstore')
 def test_lifecycle_expiration_header_and_tags_head():
     now = datetime.datetime.now(None)
     bucket_name = get_new_bucket()
@@ -9812,6 +9964,7 @@ def test_lifecycle_expiration_header_and_tags_head():
 @attr(method='put')
 @attr(operation='set lifecycle config with noncurrent version expiration')
 @attr('lifecycle')
+@attr('fails_on_dbstore')
 def test_lifecycle_set_noncurrent():
     bucket_name = _create_objects(keys=['past/foo', 'future/bar'])
     client = get_client()
@@ -9827,6 +9980,7 @@ def test_lifecycle_set_noncurrent():
 @attr('lifecycle')
 @attr('lifecycle_expiration')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_lifecycle_noncur_expiration():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9856,6 +10010,7 @@ def test_lifecycle_noncur_expiration():
 @attr(method='put')
 @attr(operation='set lifecycle config with delete marker expiration')
 @attr('lifecycle')
+@attr('fails_on_dbstore')
 def test_lifecycle_set_deletemarker():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9868,6 +10023,7 @@ def test_lifecycle_set_deletemarker():
 @attr(method='put')
 @attr(operation='set lifecycle config with Filter')
 @attr('lifecycle')
+@attr('fails_on_dbstore')
 def test_lifecycle_set_filter():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9880,6 +10036,7 @@ def test_lifecycle_set_filter():
 @attr(method='put')
 @attr(operation='set lifecycle config with empty Filter')
 @attr('lifecycle')
+@attr('fails_on_dbstore')
 def test_lifecycle_set_empty_filter():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9894,6 +10051,7 @@ def test_lifecycle_set_empty_filter():
 @attr('lifecycle')
 @attr('lifecycle_expiration')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_lifecycle_deletemarker_expiration():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9929,6 +10087,7 @@ def test_lifecycle_deletemarker_expiration():
 @attr(method='put')
 @attr(operation='set lifecycle config with multipart expiration')
 @attr('lifecycle')
+@attr('fails_on_dbstore')
 def test_lifecycle_set_multipart():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9948,6 +10107,7 @@ def test_lifecycle_set_multipart():
 @attr('lifecycle')
 @attr('lifecycle_expiration')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_lifecycle_multipart_expiration():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9984,6 +10144,7 @@ def test_lifecycle_multipart_expiration():
 @attr(operation='set lifecycle config transition with not iso8601 date')
 @attr('lifecycle')
 @attr(assertion='fails 400')
+@attr('fails_on_dbstore')
 def test_lifecycle_transition_set_invalid_date():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -10026,6 +10187,7 @@ def _test_encryption_sse_customer_write(file_size):
 @attr('lifecycle')
 @attr('lifecycle_transition')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_lifecycle_transition():
     sc = configured_storage_classes()
     if len(sc) < 3:
@@ -10074,6 +10236,7 @@ def test_lifecycle_transition():
 @attr('lifecycle')
 @attr('lifecycle_transition')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_lifecycle_transition_single_rule_multi_trans():
     sc = configured_storage_classes()
     if len(sc) < 3:
@@ -10119,6 +10282,7 @@ def test_lifecycle_transition_single_rule_multi_trans():
 @attr(operation='set lifecycle config with noncurrent version expiration')
 @attr('lifecycle')
 @attr('lifecycle_transition')
+@attr('fails_on_dbstore')
 def test_lifecycle_set_noncurrent_transition():
     sc = configured_storage_classes()
     if len(sc) < 3:
@@ -10160,6 +10324,7 @@ def test_lifecycle_set_noncurrent_transition():
 @attr('lifecycle_expiration')
 @attr('lifecycle_transition')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_lifecycle_noncur_transition():
     sc = configured_storage_classes()
     if len(sc) < 3:
@@ -10241,6 +10406,7 @@ def verify_object(client, bucket, key, content=None, sc=None):
 @attr('lifecycle_transition')
 @attr('cloud_transition')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_lifecycle_cloud_transition():
     cloud_sc = get_cloud_storage_class()
     if cloud_sc == None:
@@ -10325,6 +10491,7 @@ def test_lifecycle_cloud_transition():
 @attr('lifecycle_transition')
 @attr('cloud_transition')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_lifecycle_cloud_multiple_transition():
     cloud_sc = get_cloud_storage_class()
     if cloud_sc == None:
@@ -10391,6 +10558,7 @@ def test_lifecycle_cloud_multiple_transition():
 @attr('lifecycle_transition')
 @attr('cloud_transition')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_lifecycle_noncur_cloud_transition():
     cloud_sc = get_cloud_storage_class()
     if cloud_sc == None:
@@ -10482,6 +10650,7 @@ def test_lifecycle_noncur_cloud_transition():
 @attr('lifecycle_transition')
 @attr('cloud_transition')
 @attr('fails_on_aws')
+@attr('fails_on_dbstore')
 def test_lifecycle_cloud_transition_large_obj():
     cloud_sc = get_cloud_storage_class()
     if cloud_sc == None:
@@ -10536,6 +10705,7 @@ def test_lifecycle_cloud_transition_large_obj():
 @attr(operation='Test SSE-C encrypted transfer 1 byte')
 @attr(assertion='success')
 @attr('encryption')
+@attr('fails_on_dbstore')
 def test_encrypted_transfer_1b():
     _test_encryption_sse_customer_write(1)
 
@@ -10545,6 +10715,7 @@ def test_encrypted_transfer_1b():
 @attr(operation='Test SSE-C encrypted transfer 1KB')
 @attr(assertion='success')
 @attr('encryption')
+@attr('fails_on_dbstore')
 def test_encrypted_transfer_1kb():
     _test_encryption_sse_customer_write(1024)
 
@@ -10554,6 +10725,7 @@ def test_encrypted_transfer_1kb():
 @attr(operation='Test SSE-C encrypted transfer 1MB')
 @attr(assertion='success')
 @attr('encryption')
+@attr('fails_on_dbstore')
 def test_encrypted_transfer_1MB():
     _test_encryption_sse_customer_write(1024*1024)
 
@@ -10563,6 +10735,7 @@ def test_encrypted_transfer_1MB():
 @attr(operation='Test SSE-C encrypted transfer 13 bytes')
 @attr(assertion='success')
 @attr('encryption')
+@attr('fails_on_dbstore')
 def test_encrypted_transfer_13b():
     _test_encryption_sse_customer_write(13)
 
@@ -10785,6 +10958,7 @@ def _check_content_using_range_enc(client, bucket_name, key, data, step, enc_hea
 @attr(assertion='successful')
 @attr('encryption')
 @attr('fails_on_aws') # allow-unordered is a non-standard extension
+@attr('fails_on_dbstore')
 def test_encryption_sse_c_multipart_upload():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -10897,6 +11071,7 @@ def test_encryption_sse_c_multipart_invalid_chunks_2():
 @attr(operation='complete multi-part upload and download with bad key')
 @attr(assertion='successful')
 @attr('encryption')
+@attr('fails_on_dbstore')
 def test_encryption_sse_c_multipart_bad_download():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -10949,6 +11124,7 @@ def test_encryption_sse_c_multipart_bad_download():
 @attr(operation='authenticated browser based upload via POST request')
 @attr(assertion='succeeds and returns written data')
 @attr('encryption')
+@attr('fails_on_dbstore')
 def test_encryption_sse_c_post_object_authenticated_request():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -11003,6 +11179,7 @@ def test_encryption_sse_c_post_object_authenticated_request():
 
 @attr(assertion='success')
 @attr('encryption')
+@attr('fails_on_dbstore')
 def _test_sse_kms_customer_write(file_size, key_id = 'testkey-1'):
     """
     Tests Create a file of A's, use it to set_contents_from_file.
@@ -11035,6 +11212,7 @@ def _test_sse_kms_customer_write(file_size, key_id = 'testkey-1'):
 @attr(operation='Test SSE-KMS encrypted does perform head properly')
 @attr(assertion='success')
 @attr('encryption')
+@attr('fails_on_dbstore')
 def test_sse_kms_method_head():
     kms_keyid = get_main_kms_keyid()
     bucket_name = get_new_bucket()
@@ -11065,6 +11243,7 @@ def test_sse_kms_method_head():
 @attr(operation='write encrypted with SSE-KMS and read without SSE-KMS')
 @attr(assertion='operation success')
 @attr('encryption')
+@attr('fails_on_dbstore')
 def test_sse_kms_present():
     kms_keyid = get_main_kms_keyid()
     bucket_name = get_new_bucket()
@@ -11089,6 +11268,7 @@ def test_sse_kms_present():
 @attr(operation='declare SSE-KMS but do not provide key_id')
 @attr(assertion='operation fails')
 @attr('encryption')
+@attr('fails_on_dbstore')
 def test_sse_kms_no_key():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -11109,6 +11289,7 @@ def test_sse_kms_no_key():
 @attr(operation='Do not declare SSE-KMS but provide key_id')
 @attr(assertion='operation successfull, no encryption')
 @attr('encryption')
+@attr('fails_on_dbstore')
 def test_sse_kms_not_declared():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -11130,6 +11311,7 @@ def test_sse_kms_not_declared():
 @attr(operation='complete KMS multi-part upload')
 @attr(assertion='successful')
 @attr('encryption')
+@attr('fails_on_dbstore')
 def test_sse_kms_multipart_upload():
     kms_keyid = get_main_kms_keyid()
     bucket_name = get_new_bucket()
@@ -11180,6 +11362,7 @@ def test_sse_kms_multipart_upload():
 @attr(operation='multipart KMS upload with bad key_id for uploading chunks')
 @attr(assertion='successful')
 @attr('encryption')
+@attr('fails_on_dbstore')
 def test_sse_kms_multipart_invalid_chunks_1():
     kms_keyid = get_main_kms_keyid()
     kms_keyid2 = get_secondary_kms_keyid()
@@ -11210,6 +11393,7 @@ def test_sse_kms_multipart_invalid_chunks_1():
 @attr(operation='multipart KMS upload with unexistent key_id for chunks')
 @attr(assertion='successful')
 @attr('encryption')
+@attr('fails_on_dbstore')
 def test_sse_kms_multipart_invalid_chunks_2():
     kms_keyid = get_main_kms_keyid()
     bucket_name = get_new_bucket()
@@ -11239,6 +11423,7 @@ def test_sse_kms_multipart_invalid_chunks_2():
 @attr(operation='authenticated KMS browser based upload via POST request')
 @attr(assertion='succeeds and returns written data')
 @attr('encryption')
+@attr('fails_on_dbstore')
 def test_sse_kms_post_object_authenticated_request():
     kms_keyid = get_main_kms_keyid()
     bucket_name = get_new_bucket()
@@ -11288,6 +11473,7 @@ def test_sse_kms_post_object_authenticated_request():
 @attr(operation='Test SSE-KMS encrypted transfer 1 byte')
 @attr(assertion='success')
 @attr('encryption')
+@attr('fails_on_dbstore')
 def test_sse_kms_transfer_1b():
     kms_keyid = get_main_kms_keyid()
     if kms_keyid is None:
@@ -11300,6 +11486,7 @@ def test_sse_kms_transfer_1b():
 @attr(operation='Test SSE-KMS encrypted transfer 1KB')
 @attr(assertion='success')
 @attr('encryption')
+@attr('fails_on_dbstore')
 def test_sse_kms_transfer_1kb():
     kms_keyid = get_main_kms_keyid()
     if kms_keyid is None:
@@ -11312,6 +11499,7 @@ def test_sse_kms_transfer_1kb():
 @attr(operation='Test SSE-KMS encrypted transfer 1MB')
 @attr(assertion='success')
 @attr('encryption')
+@attr('fails_on_dbstore')
 def test_sse_kms_transfer_1MB():
     kms_keyid = get_main_kms_keyid()
     if kms_keyid is None:
@@ -11324,6 +11512,7 @@ def test_sse_kms_transfer_1MB():
 @attr(operation='Test SSE-KMS encrypted transfer 13 bytes')
 @attr(assertion='success')
 @attr('encryption')
+@attr('fails_on_dbstore')
 def test_sse_kms_transfer_13b():
     kms_keyid = get_main_kms_keyid()
     if kms_keyid is None:
@@ -11336,6 +11525,7 @@ def test_sse_kms_transfer_13b():
 @attr(operation='write encrypted with SSE-KMS and read with SSE-KMS')
 @attr(assertion='operation fails')
 @attr('encryption')
+@attr('fails_on_dbstore')
 def test_sse_kms_read_declare():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -11755,6 +11945,7 @@ def _make_random_string(size):
 @attr(operation='Test Get/PutObjTagging output')
 @attr(assertion='success')
 @attr('tagging')
+@attr('fails_on_dbstore')
 def test_get_obj_tagging():
     key = 'testputtags'
     bucket_name = _create_key_with_random_content(key)
@@ -11792,6 +11983,7 @@ def test_get_obj_head_tagging():
 @attr(operation='Test Put max allowed tags')
 @attr(assertion='success')
 @attr('tagging')
+@attr('fails_on_dbstore')
 def test_put_max_tags():
     key = 'testputmaxtags'
     bucket_name = _create_key_with_random_content(key)
@@ -11905,6 +12097,7 @@ def test_put_excess_val_tags():
 @attr(operation='Test PUT modifies existing tags')
 @attr(assertion='success')
 @attr('tagging')
+@attr('fails_on_dbstore')
 def test_put_modify_tags():
     key = 'testputmodifytags'
     bucket_name = _create_key_with_random_content(key)
@@ -11938,6 +12131,7 @@ def test_put_modify_tags():
 @attr(operation='Test Delete tags')
 @attr(assertion='success')
 @attr('tagging')
+@attr('fails_on_dbstore')
 def test_put_delete_tags():
     key = 'testputmodifytags'
     bucket_name = _create_key_with_random_content(key)
@@ -11961,6 +12155,7 @@ def test_put_delete_tags():
 @attr(operation='anonymous browser based upload via POST request')
 @attr('tagging')
 @attr(assertion='succeeds and returns written data')
+@attr('fails_on_dbstore')
 def test_post_object_tags_anonymous_request():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -12046,6 +12241,7 @@ def test_post_object_tags_authenticated_request():
 @attr(operation='Test PutObj with tagging headers')
 @attr(assertion='success')
 @attr('tagging')
+@attr('fails_on_dbstore')
 def test_put_obj_with_tags():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -12082,6 +12278,7 @@ def _make_arn_resource(path="*"):
 @attr(assertion='success')
 @attr('tagging')
 @attr('bucket-policy')
+@attr('fails_on_dbstore')
 def test_get_tags_acl_public():
     key = 'testputtagsacl'
     bucket_name = _create_key_with_random_content(key)
@@ -12108,6 +12305,7 @@ def test_get_tags_acl_public():
 @attr(assertion='success')
 @attr('tagging')
 @attr('bucket-policy')
+@attr('fails_on_dbstore')
 def test_put_tags_acl_public():
     key = 'testputtagsacl'
     bucket_name = _create_key_with_random_content(key)
@@ -12242,6 +12440,7 @@ def test_versioning_bucket_multipart_upload_return_version_id():
 @attr(assertion='success')
 @attr('tagging')
 @attr('bucket-policy')
+@attr('fails_on_dbstore')
 def test_bucket_policy_get_obj_existing_tag():
     bucket_name = _create_objects(keys=['publictag', 'privatetag', 'invalidtag'])
     client = get_client()
@@ -12300,6 +12499,7 @@ def test_bucket_policy_get_obj_existing_tag():
 @attr(assertion='success')
 @attr('tagging')
 @attr('bucket-policy')
+@attr('fails_on_dbstore')
 def test_bucket_policy_get_obj_tagging_existing_tag():
     bucket_name = _create_objects(keys=['publictag', 'privatetag', 'invalidtag'])
     client = get_client()
@@ -12365,6 +12565,7 @@ def test_bucket_policy_get_obj_tagging_existing_tag():
 @attr(assertion='success')
 @attr('tagging')
 @attr('bucket-policy')
+@attr('fails_on_dbstore')
 def test_bucket_policy_put_obj_tagging_existing_tag():
     bucket_name = _create_objects(keys=['publictag', 'privatetag', 'invalidtag'])
     client = get_client()
@@ -12437,6 +12638,7 @@ def test_bucket_policy_put_obj_tagging_existing_tag():
 @attr(assertion='success')
 @attr('tagging')
 @attr('bucket-policy')
+@attr('fails_on_dbstore')
 def test_bucket_policy_put_obj_copy_source():
     bucket_name = _create_objects(keys=['public/foo', 'public/bar', 'private/foo'])
     client = get_client()
@@ -12487,6 +12689,7 @@ def test_bucket_policy_put_obj_copy_source():
 @attr(assertion='success')
 @attr('tagging')
 @attr('bucket-policy')
+@attr('fails_on_dbstore')
 def test_bucket_policy_put_obj_copy_source_meta():
     src_bucket_name = _create_objects(keys=['public/foo', 'public/bar'])
     client = get_client()
@@ -12585,6 +12788,7 @@ def test_bucket_policy_put_obj_acl():
 @attr(operation='Test put obj with amz-grant back to bucket-owner')
 @attr(assertion='success')
 @attr('bucket-policy')
+@attr('fails_on_dbstore')
 def test_bucket_policy_put_obj_grant():
 
     bucket_name = get_new_bucket()
@@ -12742,6 +12946,7 @@ def test_bucket_policy_put_obj_request_obj_tag():
 @attr(assertion='success')
 @attr('tagging')
 @attr('bucket-policy')
+@attr('fails_on_dbstore')
 def test_bucket_policy_get_obj_acl_existing_tag():
     bucket_name = _create_objects(keys=['publictag', 'privatetag', 'invalidtag'])
     client = get_client()
@@ -12805,6 +13010,7 @@ def test_bucket_policy_get_obj_acl_existing_tag():
 @attr(operation='Test put object lock with defalut retention')
 @attr(assertion='success')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_put_obj_lock():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -12842,6 +13048,7 @@ def test_object_lock_put_obj_lock():
 @attr(operation='Test put object lock with bucket object lock not enabled')
 @attr(assertion='fails')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_put_obj_lock_invalid_bucket():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -12864,6 +13071,7 @@ def test_object_lock_put_obj_lock_invalid_bucket():
 @attr(operation='Test put object lock with days and years')
 @attr(assertion='fails')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_put_obj_lock_with_days_and_years():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -12887,6 +13095,7 @@ def test_object_lock_put_obj_lock_with_days_and_years():
 @attr(operation='Test put object lock with invalid days')
 @attr(assertion='fails')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_put_obj_lock_invalid_days():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -12909,6 +13118,7 @@ def test_object_lock_put_obj_lock_invalid_days():
 @attr(operation='Test put object lock with invalid years')
 @attr(assertion='fails')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_put_obj_lock_invalid_years():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -12931,6 +13141,7 @@ def test_object_lock_put_obj_lock_invalid_years():
 @attr(operation='Test put object lock with invalid mode')
 @attr(assertion='fails')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_put_obj_lock_invalid_years():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -12965,6 +13176,7 @@ attr(resource='bucket')
 @attr(operation='Test put object lock with invalid status')
 @attr(assertion='fails')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_put_obj_lock_invalid_status():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -12987,6 +13199,7 @@ attr(resource='bucket')
 @attr(operation='Test suspend versioning when object lock enabled')
 @attr(assertion='fails')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_suspend_versioning():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -13002,6 +13215,7 @@ def test_object_lock_suspend_versioning():
 @attr(operation='Test get object lock')
 @attr(assertion='success')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_get_obj_lock():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -13025,6 +13239,7 @@ def test_object_lock_get_obj_lock():
 @attr(operation='Test get object lock with bucket object lock not enabled')
 @attr(assertion='fails')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_get_obj_lock_invalid_bucket():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -13040,6 +13255,7 @@ def test_object_lock_get_obj_lock_invalid_bucket():
 @attr(operation='Test put object retention')
 @attr(assertion='success')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_put_obj_retention():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -13059,6 +13275,7 @@ def test_object_lock_put_obj_retention():
 @attr(operation='Test put object retention with bucket object lock not enabled')
 @attr(assertion='fails')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_put_obj_retention_invalid_bucket():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -13077,6 +13294,7 @@ def test_object_lock_put_obj_retention_invalid_bucket():
 @attr(operation='Test put object retention with invalid mode')
 @attr(assertion='fails')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_put_obj_retention_invalid_mode():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -13101,6 +13319,7 @@ def test_object_lock_put_obj_retention_invalid_mode():
 @attr(operation='Test get object retention')
 @attr(assertion='success')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_get_obj_retention():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -13120,6 +13339,7 @@ def test_object_lock_get_obj_retention():
 @attr(operation='Test object retention date formatting')
 @attr(assertion='success')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_get_obj_retention_iso8601():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -13142,6 +13362,7 @@ def test_object_lock_get_obj_retention_iso8601():
 @attr(operation='Test get object retention with invalid bucket')
 @attr(assertion='fails')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_get_obj_retention_invalid_bucket():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -13159,6 +13380,7 @@ def test_object_lock_get_obj_retention_invalid_bucket():
 @attr(operation='Test put object retention with version id')
 @attr(assertion='success')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_put_obj_retention_versionid():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -13179,6 +13401,7 @@ def test_object_lock_put_obj_retention_versionid():
 @attr(operation='Test put object retention to override default retention')
 @attr(assertion='success')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_put_obj_retention_override_default_retention():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -13208,6 +13431,7 @@ def test_object_lock_put_obj_retention_override_default_retention():
 @attr(operation='Test put object retention to increase retention period')
 @attr(assertion='success')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_put_obj_retention_increase_period():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -13229,6 +13453,7 @@ def test_object_lock_put_obj_retention_increase_period():
 @attr(operation='Test put object retention to shorten period')
 @attr(assertion='fails')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_put_obj_retention_shorten_period():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -13251,6 +13476,7 @@ def test_object_lock_put_obj_retention_shorten_period():
 @attr(operation='Test put object retention to shorten period with bypass header')
 @attr(assertion='success')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_put_obj_retention_shorten_period_bypass():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -13272,6 +13498,7 @@ def test_object_lock_put_obj_retention_shorten_period_bypass():
 @attr(operation='Test delete object with retention')
 @attr(assertion='retention period make effects')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_delete_object_with_retention():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -13295,6 +13522,7 @@ def test_object_lock_delete_object_with_retention():
 @attr(operation='Test multi-delete object with retention')
 @attr(assertion='retention period make effects')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_multi_delete_object_with_retention():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -13366,6 +13594,7 @@ def test_object_lock_multi_delete_object_with_retention():
 @attr(operation='Test put legal hold')
 @attr(assertion='success')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_put_legal_hold():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -13384,6 +13613,7 @@ def test_object_lock_put_legal_hold():
 @attr(operation='Test put legal hold with invalid bucket')
 @attr(assertion='fails')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_put_legal_hold_invalid_bucket():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -13402,6 +13632,7 @@ def test_object_lock_put_legal_hold_invalid_bucket():
 @attr(operation='Test put legal hold with invalid status')
 @attr(assertion='fails')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_put_legal_hold_invalid_status():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -13420,6 +13651,7 @@ def test_object_lock_put_legal_hold_invalid_status():
 @attr(operation='Test get legal hold')
 @attr(assertion='success')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_get_legal_hold():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -13441,6 +13673,7 @@ def test_object_lock_get_legal_hold():
 @attr(operation='Test get legal hold with invalid bucket')
 @attr(assertion='fails')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_get_legal_hold_invalid_bucket():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -13458,6 +13691,7 @@ def test_object_lock_get_legal_hold_invalid_bucket():
 @attr(operation='Test delete object with legal hold on')
 @attr(assertion='fails')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_delete_object_with_legal_hold_on():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -13477,6 +13711,7 @@ def test_object_lock_delete_object_with_legal_hold_on():
 @attr(operation='Test delete object with legal hold off')
 @attr(assertion='fails')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_delete_object_with_legal_hold_off():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -13493,6 +13728,7 @@ def test_object_lock_delete_object_with_legal_hold_off():
 @attr(operation='Test get object metadata')
 @attr(assertion='success')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_get_obj_metadata():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -13517,6 +13753,7 @@ def test_object_lock_get_obj_metadata():
 @attr(operation='Test put legal hold and retention when uploading object')
 @attr(assertion='success')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_uploading_obj():
     bucket_name = get_new_bucket_name()
     client = get_client()
@@ -13537,6 +13774,7 @@ def test_object_lock_uploading_obj():
 @attr(operation='Test changing object retention mode from GOVERNANCE to COMPLIANCE with bypass')
 @attr(assertion='succeeds')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_changing_mode_from_governance_with_bypass():
     bucket_name = get_new_bucket_name()
     key = 'file1'
@@ -13555,6 +13793,7 @@ def test_object_lock_changing_mode_from_governance_with_bypass():
 @attr(operation='Test changing object retention mode from GOVERNANCE to COMPLIANCE without bypass')
 @attr(assertion='fails')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_changing_mode_from_governance_without_bypass():
     bucket_name = get_new_bucket_name()
     key = 'file1'
@@ -13576,6 +13815,7 @@ def test_object_lock_changing_mode_from_governance_without_bypass():
 @attr(operation='Test changing object retention mode from COMPLIANCE to GOVERNANCE')
 @attr(assertion='fails')
 @attr('object-lock')
+@attr('fails_on_dbstore')
 def test_object_lock_changing_mode_from_compliance():
     bucket_name = get_new_bucket_name()
     key = 'file1'
@@ -13596,6 +13836,7 @@ def test_object_lock_changing_mode_from_compliance():
 @attr(method='copy')
 @attr(operation='copy w/ x-amz-copy-source-if-match: the latest ETag')
 @attr(assertion='succeeds')
+@attr('fails_on_dbstore')
 def test_copy_object_ifmatch_good():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -13642,6 +13883,7 @@ def test_copy_object_ifnonematch_good():
 @attr(method='copy')
 @attr(operation='copy w/ x-amz-copy-source-if-none-match: bogus ETag')
 @attr(assertion='succeeds')
+@attr('fails_on_dbstore')
 def test_copy_object_ifnonematch_failed():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -13671,6 +13913,7 @@ def test_object_read_unreadable():
 @attr(operation='Test User Policy')
 @attr(assertion='succeeds')
 @attr('user-policy')
+@attr('fails_on_dbstore')
 def test_user_policy():
     client = get_tenant_iam_client()
 
@@ -13965,6 +14208,7 @@ def test_block_public_policy():
 @attr(operation='ignore public acls on canned acls')
 @attr(assertion='succeeds')
 @attr('policy_status')
+@attr('fails_on_dbstore')
 def test_ignore_public_acls():
     bucket_name = get_new_bucket()
     client = get_client()

--- a/s3tests_boto3/functional/test_sts.py
+++ b/s3tests_boto3/functional/test_sts.py
@@ -154,6 +154,7 @@ def get_s3_resource_using_iam_creds():
 @attr(operation='check')
 @attr(assertion='s3 ops only accessible by temporary credentials')
 @attr('test_of_sts')
+@attr('fails_on_dbstore')
 def test_get_session_token():
     iam_client=get_iam_client()
     sts_client=get_sts_client()
@@ -187,6 +188,7 @@ def test_get_session_token():
 @attr(operation='check')
 @attr(assertion='s3 ops denied by permanent credentials')
 @attr('test_of_sts')
+@attr('fails_on_dbstore')
 def test_get_session_token_permanent_creds_denied():
     s3bucket_error=None
     iam_client=get_iam_client()
@@ -223,6 +225,7 @@ def test_get_session_token_permanent_creds_denied():
 @attr(operation='check')
 @attr(assertion='role policy allows all s3 ops')
 @attr('test_of_sts')
+@attr('fails_on_dbstore')
 def test_assume_role_allow():
     iam_client=get_iam_client()    
     sts_client=get_sts_client()
@@ -259,6 +262,7 @@ def test_assume_role_allow():
 @attr(operation='check')
 @attr(assertion='role policy denies all s3 ops')
 @attr('test_of_sts')
+@attr('fails_on_dbstore')
 def test_assume_role_deny():
     s3bucket_error=None
     iam_client=get_iam_client()    
@@ -297,6 +301,7 @@ def test_assume_role_deny():
 @attr(operation='check')
 @attr(assertion='creds expire so all s3 ops fails')
 @attr('test_of_sts')
+@attr('fails_on_dbstore')
 def test_assume_role_creds_expiry():
     iam_client=get_iam_client()    
     sts_client=get_sts_client()
@@ -335,6 +340,7 @@ def test_assume_role_creds_expiry():
 @attr(operation='check')
 @attr(assertion='HEAD fails with 403 when role policy denies s3:ListBucket')
 @attr('test_of_sts')
+@attr('fails_on_dbstore')
 def test_assume_role_deny_head_nonexistent():
     # create a bucket with the normal s3 client
     bucket_name = get_new_bucket_name()
@@ -376,6 +382,7 @@ def test_assume_role_deny_head_nonexistent():
 @attr(operation='check')
 @attr(assertion='HEAD fails with 404 when role policy allows s3:ListBucket')
 @attr('test_of_sts')
+@attr('fails_on_dbstore')
 def test_assume_role_allow_head_nonexistent():
     # create a bucket with the normal s3 client
     bucket_name = get_new_bucket_name()
@@ -419,6 +426,7 @@ def test_assume_role_allow_head_nonexistent():
 @attr(assertion='assuming role through web token')
 @attr('webidentity_test')
 @attr('token_claims_trust_policy_test')
+@attr('fails_on_dbstore')
 def test_assume_role_with_web_identity():
     check_webidentity()
     iam_client=get_iam_client()    
@@ -522,6 +530,7 @@ def test_assume_role_with_web_identity_invalid_webtoken():
 @attr(assertion='checking session policy working for two different buckets')
 @attr('webidentity_test')
 @attr('session_policy')
+@attr('fails_on_dbstore')
 def test_session_policy_check_on_different_buckets():
     check_webidentity()
     iam_client=get_iam_client()
@@ -594,6 +603,7 @@ def test_session_policy_check_on_different_buckets():
 @attr(assertion='checking session policy working for same bucket')
 @attr('webidentity_test')
 @attr('session_policy')
+@attr('fails_on_dbstore')
 def test_session_policy_check_on_same_bucket():
     check_webidentity()
     iam_client=get_iam_client()
@@ -654,6 +664,7 @@ def test_session_policy_check_on_same_bucket():
 @attr(assertion='checking put_obj op denial')
 @attr('webidentity_test')
 @attr('session_policy')
+@attr('fails_on_dbstore')
 def test_session_policy_check_put_obj_denial():
     check_webidentity()
     iam_client=get_iam_client()
@@ -719,6 +730,7 @@ def test_session_policy_check_put_obj_denial():
 @attr(assertion='checking put_obj working by swapping policies')
 @attr('webidentity_test')
 @attr('session_policy')
+@attr('fails_on_dbstore')
 def test_swapping_role_policy_and_session_policy():
     check_webidentity()
     iam_client=get_iam_client()
@@ -779,6 +791,7 @@ def test_swapping_role_policy_and_session_policy():
 @attr(assertion='checking put_obj working by setting different permissions to role and session policy')
 @attr('webidentity_test')
 @attr('session_policy')
+@attr('fails_on_dbstore')
 def test_session_policy_check_different_op_permissions():
     check_webidentity()
     iam_client=get_iam_client()
@@ -844,6 +857,7 @@ def test_session_policy_check_different_op_permissions():
 @attr(assertion='checking op behaviour with deny effect')
 @attr('webidentity_test')
 @attr('session_policy')
+@attr('fails_on_dbstore')
 def test_session_policy_check_with_deny_effect():
     check_webidentity()
     iam_client=get_iam_client()
@@ -908,6 +922,7 @@ def test_session_policy_check_with_deny_effect():
 @attr(assertion='checking put_obj working with deny and allow on same op')
 @attr('webidentity_test')
 @attr('session_policy')
+@attr('fails_on_dbstore')
 def test_session_policy_check_with_deny_on_same_op():
     check_webidentity()
     iam_client=get_iam_client()
@@ -972,6 +987,7 @@ def test_session_policy_check_with_deny_on_same_op():
 @attr(assertion='checking op when bucket policy has role arn')
 @attr('webidentity_test')
 @attr('session_policy')
+@attr('fails_on_dbstore')
 def test_session_policy_bucket_policy_role_arn():
     check_webidentity()
     iam_client=get_iam_client()
@@ -1051,6 +1067,7 @@ def test_session_policy_bucket_policy_role_arn():
 @attr(assertion='checking op when bucket policy has session arn')
 @attr('webidentity_test')
 @attr('session_policy')
+@attr('fails_on_dbstore')
 def test_session_policy_bucket_policy_session_arn():
     check_webidentity()
     iam_client=get_iam_client()
@@ -1128,6 +1145,7 @@ def test_session_policy_bucket_policy_session_arn():
 @attr(assertion='checking copy object op with role, session and bucket policy')
 @attr('webidentity_test')
 @attr('session_policy')
+@attr('fails_on_dbstore')
 def test_session_policy_copy_object():
     check_webidentity()
     iam_client=get_iam_client()
@@ -1212,6 +1230,7 @@ def test_session_policy_copy_object():
 @attr(assertion='checking op is denied when no role policy')
 @attr('webidentity_test')
 @attr('session_policy')
+@attr('fails_on_dbstore')
 def test_session_policy_no_bucket_role_policy():
     check_webidentity()
     iam_client=get_iam_client()
@@ -1267,6 +1286,7 @@ def test_session_policy_no_bucket_role_policy():
 @attr(assertion='checking op is denied when resource policy denies')
 @attr('webidentity_test')
 @attr('session_policy')
+@attr('fails_on_dbstore')
 def test_session_policy_bucket_policy_deny():
     check_webidentity()
     iam_client=get_iam_client()
@@ -1344,6 +1364,7 @@ def test_session_policy_bucket_policy_deny():
 @attr(assertion='assuming role using web token using sub in trust policy')
 @attr('webidentity_test')
 @attr('token_claims_trust_policy_test')
+@attr('fails_on_dbstore')
 def test_assume_role_with_web_identity_with_sub():
     check_webidentity()
     iam_client=get_iam_client()
@@ -1396,6 +1417,7 @@ def test_assume_role_with_web_identity_with_sub():
 @attr(assertion='assuming role using web token using azp in trust policy')
 @attr('webidentity_test')
 @attr('token_claims_trust_policy_test')
+@attr('fails_on_dbstore')
 def test_assume_role_with_web_identity_with_azp():
     check_webidentity()
     iam_client=get_iam_client()
@@ -1449,6 +1471,7 @@ def test_assume_role_with_web_identity_with_azp():
 @attr('webidentity_test')
 @attr('abac_test')
 @attr('token_request_tag_trust_policy_test')
+@attr('fails_on_dbstore')
 def test_assume_role_with_web_identity_with_request_tag():
     check_webidentity()
     iam_client=get_iam_client()
@@ -1501,6 +1524,7 @@ def test_assume_role_with_web_identity_with_request_tag():
 @attr('webidentity_test')
 @attr('abac_test')
 @attr('token_principal_tag_role_policy_test')
+@attr('fails_on_dbstore')
 def test_assume_role_with_web_identity_with_principal_tag():
     check_webidentity()
     iam_client=get_iam_client()
@@ -1553,6 +1577,7 @@ def test_assume_role_with_web_identity_with_principal_tag():
 @attr('webidentity_test')
 @attr('abac_test')
 @attr('token_principal_tag_role_policy_test')
+@attr('fails_on_dbstore')
 def test_assume_role_with_web_identity_for_all_values():
     check_webidentity()
     iam_client=get_iam_client()
@@ -1605,6 +1630,7 @@ def test_assume_role_with_web_identity_for_all_values():
 @attr('webidentity_test')
 @attr('abac_test')
 @attr('token_principal_tag_role_policy_test')
+@attr('fails_on_dbstore')
 def test_assume_role_with_web_identity_for_all_values_deny():
     check_webidentity()
     iam_client=get_iam_client()
@@ -1659,6 +1685,7 @@ def test_assume_role_with_web_identity_for_all_values_deny():
 @attr('webidentity_test')
 @attr('abac_test')
 @attr('token_tag_keys_test')
+@attr('fails_on_dbstore')
 def test_assume_role_with_web_identity_tag_keys_trust_policy():
     check_webidentity()
     iam_client=get_iam_client()
@@ -1711,6 +1738,7 @@ def test_assume_role_with_web_identity_tag_keys_trust_policy():
 @attr('webidentity_test')
 @attr('abac_test')
 @attr('token_tag_keys_test')
+@attr('fails_on_dbstore')
 def test_assume_role_with_web_identity_tag_keys_role_policy():
     check_webidentity()
     iam_client=get_iam_client()
@@ -1763,6 +1791,7 @@ def test_assume_role_with_web_identity_tag_keys_role_policy():
 @attr('webidentity_test')
 @attr('abac_test')
 @attr('token_resource_tags_test')
+@attr('fails_on_dbstore')
 def test_assume_role_with_web_identity_resource_tag():
     check_webidentity()
     iam_client=get_iam_client()
@@ -1825,6 +1854,7 @@ def test_assume_role_with_web_identity_resource_tag():
 @attr('webidentity_test')
 @attr('abac_test')
 @attr('token_resource_tags_test')
+@attr('fails_on_dbstore')
 def test_assume_role_with_web_identity_resource_tag_deny():
     check_webidentity()
     iam_client=get_iam_client()
@@ -1887,6 +1917,7 @@ def test_assume_role_with_web_identity_resource_tag_deny():
 @attr('webidentity_test')
 @attr('abac_test')
 @attr('token_resource_tags_test')
+@attr('fails_on_dbstore')
 def test_assume_role_with_web_identity_wrong_resource_tag_deny():
     check_webidentity()
     iam_client=get_iam_client()
@@ -1952,6 +1983,7 @@ def test_assume_role_with_web_identity_wrong_resource_tag_deny():
 @attr('webidentity_test')
 @attr('abac_test')
 @attr('token_resource_tags_test')
+@attr('fails_on_dbstore')
 def test_assume_role_with_web_identity_resource_tag_princ_tag():
     check_webidentity()
     iam_client=get_iam_client()
@@ -2019,6 +2051,7 @@ def test_assume_role_with_web_identity_resource_tag_princ_tag():
 @attr('webidentity_test')
 @attr('abac_test')
 @attr('token_resource_tags_test')
+@attr('fails_on_dbstore')
 def test_assume_role_with_web_identity_resource_tag_copy_obj():
     check_webidentity()
     iam_client=get_iam_client()
@@ -2113,6 +2146,7 @@ def test_assume_role_with_web_identity_resource_tag_copy_obj():
 @attr('webidentity_test')
 @attr('abac_test')
 @attr('token_role_tags_test')
+@attr('fails_on_dbstore')
 def test_assume_role_with_web_identity_role_resource_tag():
     check_webidentity()
     iam_client=get_iam_client()


### PR DESCRIPTION
To be able to successfully run s3tests on dbstore backend in teuthology, mark all the s3-tests currently failing on it with 'fails_on_dbstore' attr

Signed-off-by: Soumya Koduri <skoduri@redhat.com>