### PR TITLE
Add attr for deprecated field Prefix

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -9105,6 +9105,7 @@ def test_versioned_concurrent_object_create_and_remove():
 @attr(method='put')
 @attr(operation='set lifecycle config')
 @attr('lifecycle')
+@attr('deprecated_field_prefix')
 def test_lifecycle_set():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9118,6 +9119,7 @@ def test_lifecycle_set():
 @attr(method='get')
 @attr(operation='get lifecycle config')
 @attr('lifecycle')
+@attr('deprecated_field_prefix')
 def test_lifecycle_get():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9132,6 +9134,7 @@ def test_lifecycle_get():
 @attr(method='get')
 @attr(operation='get lifecycle config no id')
 @attr('lifecycle')
+@attr('deprecated_field_prefix')
 def test_lifecycle_get_no_id():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9168,6 +9171,7 @@ def test_lifecycle_get_no_id():
 @attr('lifecycle')
 @attr('lifecycle_expiration')
 @attr('fails_on_aws')
+@attr('deprecated_field_prefix')
 def test_lifecycle_expiration():
     bucket_name = _create_objects(keys=['expire1/foo', 'expire1/bar', 'keep2/foo',
                                         'keep2/bar', 'expire3/foo', 'expire3/bar'])
@@ -9205,6 +9209,7 @@ def test_lifecycle_expiration():
 @attr('lifecycle_expiration')
 @attr('fails_on_aws')
 @attr('list-objects-v2')
+@attr('deprecated_field_prefix')
 def test_lifecyclev2_expiration():
     bucket_name = _create_objects(keys=['expire1/foo', 'expire1/bar', 'keep2/foo',
                                         'keep2/bar', 'expire3/foo', 'expire3/bar'])
@@ -9241,6 +9246,7 @@ def test_lifecyclev2_expiration():
 @attr('lifecycle')
 @attr('lifecycle_expiration')
 @attr('fails_on_aws')
+@attr('deprecated_field_prefix')
 def test_lifecycle_expiration_versioning_enabled():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9500,6 +9506,7 @@ def test_lifecycle_expiration_noncur_tags1():
 @attr(operation='id too long in lifecycle rule')
 @attr('lifecycle')
 @attr(assertion='fails 400')
+@attr('deprecated_field_prefix')
 def test_lifecycle_id_too_long():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9516,6 +9523,7 @@ def test_lifecycle_id_too_long():
 @attr(operation='same id')
 @attr('lifecycle')
 @attr(assertion='fails 400')
+@attr('deprecated_field_prefix')
 def test_lifecycle_same_id():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9564,6 +9572,7 @@ def test_lifecycle_invalid_status():
 @attr(method='put')
 @attr(operation='set lifecycle config with expiration date')
 @attr('lifecycle')
+@attr('deprecated_field_prefix')
 def test_lifecycle_set_date():
     bucket_name = get_new_bucket()
     client = get_client()
@@ -9812,6 +9821,7 @@ def test_lifecycle_expiration_header_and_tags_head():
 @attr(method='put')
 @attr(operation='set lifecycle config with noncurrent version expiration')
 @attr('lifecycle')
+@attr('deprecated_field_prefix')
 def test_lifecycle_set_noncurrent():
     bucket_name = _create_objects(keys=['past/foo', 'future/bar'])
     client = get_client()


### PR DESCRIPTION
Lifecycle Configuration
Old:
<LifecycleConfiguration>
  <Rule>
       <Prefix>tax/</Prefix>
...

New:
<LifecycleConfiguration>
  <Rule>
    <Filter>
       <Prefix>tax/</Prefix>
    </Filter>
    ...

from https://docs.aws.amazon.com/cli/latest/reference/s3api/get-bucket-lifecycle-configuration.html

"Prefix identifying one or more objects to which the rule applies. This is no longer used; use Filter instead."

However, AWS still accept it.