### PR TITLE
s3tests.conf.SAMPLE: comment out [s3 cloud] section

### DIFF
--- a/s3tests.conf.SAMPLE
+++ b/s3tests.conf.SAMPLE
@@ -62,7 +62,7 @@ access_key = NOPQRSTUVWXYZABCDEFG
 # alt AWS secret key set in vstart.sh
 secret_key = nopqrstuvwxyzabcdefghijklmnabcdefghijklm
 
-[s3 cloud]
+#[s3 cloud]
 ## to run the testcases with "cloud_transition" attribute.
 ## Note: the waiting time may have to tweaked depending on
 ## the I/O latency to the cloud endpoint.


### PR DESCRIPTION
fixes this error when trying to run against `s3tests.conf.SAMPLE`:
```
~/s3-tests $ S3TEST_CONF=s3tests.conf.SAMPLE virtualenv/bin/nosetests s3tests_boto3/functional/test_s3.py        
ERROR                                                                                                                                                         
                                                                                                                                                              
======================================================================                                                                                        
ERROR: test suite for <module 's3tests_boto3.functional.test_s3' from 's3-tests/s3tests_boto3/functional/test_s3.py'>                           
----------------------------------------------------------------------
Traceback (most recent call last):
  File "s3-tests/virtualenv/lib/python3.6/site-packages/nose/suite.py", line 210, in run
    self.setUp()
  File "s3-tests/virtualenv/lib/python3.6/site-packages/nose/suite.py", line 293, in setUp
    self.setupContext(ancestor)
  File "s3-tests/virtualenv/lib/python3.6/site-packages/nose/suite.py", line 316, in setupContext
    try_run(context, names)
  File "s3-tests/virtualenv/lib/python3.6/site-packages/nose/util.py", line 471, in try_run
    return func()
  File "s3-tests/s3tests_boto3/functional/__init__.py", line 281, in setup
    get_cloud_config(cfg)
  File "s3-tests/s3tests_boto3/functional/__init__.py", line 340, in get_cloud_config
    config.cloud_access_key = cfg.get('s3 cloud',"access_key")
  File "/usr/lib64/python3.6/configparser.py", line 792, in get
    raise NoOptionError(option, section)
configparser.NoOptionError: No option 'access_key' in section: 's3 cloud'
-------------------- >> begin captured stdout << ---------------------
```
with the `[s3 cloud]` section commented out, the cloud transition tests are skipped:
```
s3tests_boto3.functional.test_s3.test_lifecycle_transition ... SKIP                                                                                           
s3tests_boto3.functional.test_s3.test_lifecycle_transition_single_rule_multi_trans ... SKIP                                                                   
s3tests_boto3.functional.test_s3.test_lifecycle_set_noncurrent_transition ... SKIP                                                                            
s3tests_boto3.functional.test_s3.test_lifecycle_cloud_transition ... SKIP                                                                                     
s3tests_boto3.functional.test_s3.test_lifecycle_cloud_multiple_transition ... SKIP                                                                            
s3tests_boto3.functional.test_s3.test_lifecycle_cloud_transition_large_obj ... SKIP
```