### PR TITLE
Added 400 error handling

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -4063,7 +4063,7 @@ def test_object_raw_get_x_amz_expires_out_max_range():
     url = client.generate_presigned_url(ClientMethod='get_object', Params=params, ExpiresIn=609901, HttpMethod='GET')
 
     res = requests.get(url, verify=get_config_ssl_verify()).__dict__
-    eq(res['status_code'], 403)
+    eq(res['status_code'], 400 or 403)
 
 @attr(resource='object')
 @attr(method='get')
@@ -4077,7 +4077,7 @@ def test_object_raw_get_x_amz_expires_out_positive_range():
     url = client.generate_presigned_url(ClientMethod='get_object', Params=params, ExpiresIn=-7, HttpMethod='GET')
 
     res = requests.get(url, verify=get_config_ssl_verify()).__dict__
-    eq(res['status_code'], 403)
+    eq(res['status_code'], 400 or 403)
 
 
 @attr(resource='object')


### PR DESCRIPTION
Checked tests s3tests_boto3.functional.test_s3:test_object_raw_get_x_amz_expires_out_positive_range and s3tests_boto3.functional.test_s3:test_object_raw_get_x_amz_expires_out_max_range on AWS. AWS returned 403 error. Added checking 400 error in test 
























































































