### PR TITLE
dbstore: mark 'test_set_bucket_tagging' as 'fails_on_dbstore'

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -7783,6 +7783,7 @@ def test_cors_header_option():
 @attr(operation='put tags')
 @attr(assertion='succeeds')
 @attr('tagging')
+@attr('fails_on_dbstore')
 def test_set_bucket_tagging():
     bucket_name = get_new_bucket()
     client = get_client()


### PR DESCRIPTION
As per below teuthology results, tests_set_bucket_tagging fails on
dbstore

http://qa-proxy.ceph.com/teuthology/soumyakoduri-2022-05-19_16:46:01-rgw:dbstore-wip-skoduri-dbstore-vstart-distro-basic-smithi/6841399/teuthology.log

Signed-off-by: Soumya Koduri <skoduri@redhat.com>