### PR TITLE
rgw/s3_boto3: Added http status code verification for DeleteBucketTagging case.

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -7759,7 +7759,9 @@ def test_set_bucket_tagging():
     eq(response['TagSet'][0]['Key'], 'Hello')
     eq(response['TagSet'][0]['Value'], 'World')
 
-    client.delete_bucket_tagging(Bucket=bucket_name)
+    response = client.delete_bucket_tagging(Bucket=bucket_name)
+    eq(response['ResponseMetadata']['HTTPStatusCode'], 204)
+
     e = assert_raises(ClientError, client.get_bucket_tagging, Bucket=bucket_name)
     status, error_code = _get_status_and_error_code(e.response)
     eq(status, 404)


### PR DESCRIPTION
Updated test_set_bucket_tagging test for verifying the http status code
for DeleteBucketTagging case.

Related CEPH PR: https://github.com/ceph/ceph/pull/47262

Signed-off-by: Shriya Deshmukh <shriya.deshmukh@seagate.com>