### PR TITLE
pin botocore to resolve v2 signature failures

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@ PyYAML
 nose >=1.0.0
 boto >=2.6.0
 boto3 >=1.0.0
+# botocore-1.28 broke v2 signatures, see https://tracker.ceph.com/issues/58059
+botocore <1.28.0
 munch >=2.0.0
 # 0.14 switches to libev, that means bootstrap needs to change too
 gevent >=1.0


### PR DESCRIPTION
it looks like ubuntu 20.04 recently updated its botocore version, and introduced a regression in v2 signatures that causes 4 test failures: https://tracker.ceph.com/issues/58059

pin `botocore <1.28.0` in requirements.txt to avoid this regression