### PR TITLE
Use get_new_bucket_name() in select tests.

### DIFF
--- a/s3tests_boto3/functional/test_s3select.py
+++ b/s3tests_boto3/functional/test_s3select.py
@@ -9,7 +9,8 @@ import uuid
 from . import (
     configfile,
     setup_teardown,
-    get_client
+    get_client,
+    get_new_bucket_name
     )
 
 import logging
@@ -86,7 +87,7 @@ def test_generate_where_clause():
 
     # create small csv file for testing the random expressions
     single_line_csv = create_random_csv_object(1,1)
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     obj_name = get_random_string() #"single_line_csv.csv"
     upload_csv_object(bucket_name,obj_name,single_line_csv)
        
@@ -98,7 +99,7 @@ def test_generate_projection():
 
     # create small csv file for testing the random expressions
     single_line_csv = create_random_csv_object(1,1)
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     obj_name = get_random_string() #"single_line_csv.csv"
     upload_csv_object(bucket_name,obj_name,single_line_csv)
        
@@ -311,7 +312,7 @@ def create_list_of_int(column_pos,obj,field_split=",",row_split="\n"):
 @pytest.mark.s3select
 def test_count_operation():
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     num_of_rows = 1234
     obj_to_load = create_random_csv_object(num_of_rows,10)
     upload_csv_object(bucket_name,csv_obj_name,obj_to_load)
@@ -324,7 +325,7 @@ def test_column_sum_min_max():
     csv_obj = create_random_csv_object(10000,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
     
     csv_obj_name_2 = get_random_string()
@@ -390,7 +391,7 @@ def test_nullif_expressions():
     csv_obj = create_random_csv_object(10000,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
     res_s3select_nullif = remove_xml_tags_from_result(  run_s3select(bucket_name,csv_obj_name,"select count(0) from s3object where nullif(_1,_2) is null ;")  ).replace("\n","")
@@ -445,7 +446,7 @@ def test_nulliftrue_expressions():
     csv_obj = create_random_csv_object(10000,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
     res_s3select_nullif = remove_xml_tags_from_result(  run_s3select(bucket_name,csv_obj_name,"select count(0) from s3object where (nullif(_1,_2) is null) = true ;")  ).replace("\n","")
@@ -472,7 +473,7 @@ def test_is_not_null_expressions():
     csv_obj = create_random_csv_object(10000,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
     res_s3select_null = remove_xml_tags_from_result(  run_s3select(bucket_name,csv_obj_name,"select count(*) from s3object where nullif(_1,_2) is not null ;")  ).replace("\n","")
@@ -493,7 +494,7 @@ def test_lowerupper_expressions():
     csv_obj = create_random_csv_object(1,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
     res_s3select = remove_xml_tags_from_result(  run_s3select(bucket_name,csv_obj_name,'select lower("AB12cd$$") from s3object ;')  ).replace("\n","")
@@ -511,7 +512,7 @@ def test_in_expressions():
     csv_obj = create_random_csv_object(10000,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
     res_s3select_in = remove_xml_tags_from_result(  run_s3select(bucket_name,csv_obj_name,'select int(_1) from s3object where int(_1) in(1);')).replace("\n","")
@@ -580,7 +581,7 @@ def test_true_false_in_expressions():
     csv_obj = create_random_csv_object(10000,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
     res_s3select_in = remove_xml_tags_from_result(  run_s3select(bucket_name,csv_obj_name,'select int(_1) from s3object where (int(_1) in(1)) = true;')).replace("\n","")
@@ -625,7 +626,7 @@ def test_like_expressions():
     csv_obj = create_random_csv_object_string(1000,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
     res_s3select_like = remove_xml_tags_from_result(  run_s3select(bucket_name,csv_obj_name,'select count(*) from s3object where _1 like "%aeio%";')).replace("\n","")
@@ -712,7 +713,7 @@ def test_truefalselike_expressions():
     csv_obj = create_random_csv_object_string(1000,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
     res_s3select_like = remove_xml_tags_from_result(  run_s3select(bucket_name,csv_obj_name,'select count(*) from s3object where (_1 like "%aeio%") = true;')).replace("\n","")
@@ -757,7 +758,7 @@ def test_nullif_expressions():
     csv_obj = create_random_csv_object(10000,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
     res_s3select_nullif = remove_xml_tags_from_result(  run_s3select(bucket_name,csv_obj_name,"select count(0) from stdin where nullif(_1,_2) is null ;")  ).replace("\n","")
@@ -784,7 +785,7 @@ def test_lowerupper_expressions():
     csv_obj = create_random_csv_object(1,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
     res_s3select = remove_xml_tags_from_result(  run_s3select(bucket_name,csv_obj_name,'select lower("AB12cd$$") from stdin ;')  ).replace("\n","")
@@ -802,7 +803,7 @@ def test_in_expressions():
     csv_obj = create_random_csv_object(10000,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
     res_s3select_in = remove_xml_tags_from_result(  run_s3select(bucket_name,csv_obj_name,'select int(_1) from stdin where int(_1) in(1);')).replace("\n","")
@@ -841,7 +842,7 @@ def test_like_expressions():
     csv_obj = create_random_csv_object_string(10000,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
     res_s3select_in = remove_xml_tags_from_result(  run_s3select(bucket_name,csv_obj_name,'select count(*) from stdin where _1 like "%aeio%";')).replace("\n","")
@@ -888,7 +889,7 @@ def test_complex_expressions():
     csv_obj = create_random_csv_object(10000,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
     res_s3select = remove_xml_tags_from_result(  run_s3select(bucket_name,csv_obj_name,"select min(int(_1)),max(int(_2)),min(int(_3))+1 from s3object;")).replace("\n","")
@@ -924,7 +925,7 @@ def test_alias():
     csv_obj = create_random_csv_object(10000,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
     res_s3select_alias = remove_xml_tags_from_result(  run_s3select(bucket_name,csv_obj_name,"select int(_1) as a1, int(_2) as a2 , (a1+a2) as a3 from s3object where a3>100 and a3<300;")  ).replace(",","")
@@ -943,7 +944,7 @@ def test_alias_cyclic_refernce():
     csv_obj = create_random_csv_object(number_of_rows,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
     res_s3select_alias = remove_xml_tags_from_result(  run_s3select(bucket_name,csv_obj_name,"select int(_1) as a1,int(_2) as a2, a1+a4 as a3, a5+a1 as a4, int(_3)+a3 as a5 from s3object;")  )
@@ -961,7 +962,7 @@ def test_datetime():
     csv_obj = create_csv_object_for_datetime(10000,1)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
 
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
@@ -992,7 +993,7 @@ def test_true_false_datetime():
     csv_obj = create_csv_object_for_datetime(10000,1)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
 
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
@@ -1025,7 +1026,7 @@ def test_csv_parser():
 
     csv_obj = r',first,,,second,third="c31,c32,c33",forth="1,2,3,4",fifth=my_string=\"any_value\" \, my_other_string=\"aaaa\,bbb\" ,' + "\n"
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
 
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
@@ -1066,7 +1067,7 @@ def test_csv_definition():
     csv_obj = create_random_csv_object(number_of_rows,10,"|","\t")
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
 
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
    
@@ -1096,7 +1097,7 @@ def test_schema_definition():
     csv_obj = create_random_csv_object(number_of_rows,10,csv_schema="c1,c2,c3,c4,c5,c6,c7,c8,c9,c10")
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
 
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
@@ -1128,7 +1129,7 @@ def test_when_then_else_expressions():
     csv_obj = create_random_csv_object(10000,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
     res_s3select = remove_xml_tags_from_result(  run_s3select(bucket_name,csv_obj_name,'select case when cast(_1 as int)>100 and cast(_1 as int)<200 then "(100-200)" when cast(_1 as int)>200 and cast(_1 as int)<300 then "(200-300)" else "NONE" end from s3object;')  ).replace("\n","")
@@ -1157,7 +1158,7 @@ def test_coalesce_expressions():
     csv_obj = create_random_csv_object(10000,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
     res_s3select = remove_xml_tags_from_result(  run_s3select(bucket_name,csv_obj_name,'select count(*) from s3object where char_length(_3)>2 and char_length(_4)>2 and cast(substring(_3,1,2) as int) = cast(substring(_4,1,2) as int);')  ).replace("\n","")  
@@ -1179,7 +1180,7 @@ def test_cast_expressions():
     csv_obj = create_random_csv_object(10000,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
     res_s3select = remove_xml_tags_from_result(  run_s3select(bucket_name,csv_obj_name,'select count(*) from s3object where cast(_3 as int)>999;')  ).replace("\n","")  
@@ -1204,7 +1205,7 @@ def test_version():
     csv_obj = create_random_csv_object(number_of_rows,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
 
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
@@ -1218,7 +1219,7 @@ def test_trim_expressions():
     csv_obj = create_random_csv_object_trim(10000,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
     res_s3select_trim = remove_xml_tags_from_result(  run_s3select(bucket_name,csv_obj_name,'select count(*) from s3object where trim(_1) = "aeiou";')).replace("\n","")
@@ -1257,7 +1258,7 @@ def test_truefalse_trim_expressions():
     csv_obj = create_random_csv_object_trim(10000,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
     res_s3select_trim = remove_xml_tags_from_result(  run_s3select(bucket_name,csv_obj_name,'select count(*) from s3object where trim(_1) = "aeiou" = true;')).replace("\n","")
@@ -1296,7 +1297,7 @@ def test_escape_expressions():
     csv_obj = create_random_csv_object_escape(10000,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
     res_s3select_escape = remove_xml_tags_from_result(  run_s3select(bucket_name,csv_obj_name,'select count(*) from s3object where _1 like "%_ar" escape "%";')).replace("\n","")
@@ -1317,7 +1318,7 @@ def test_case_value_expressions():
     csv_obj = create_random_csv_object(10000,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
     res_s3select_case = remove_xml_tags_from_result(  run_s3select(bucket_name,csv_obj_name,'select case cast(_1 as int) when cast(_2 as int) then "case_1_1" else "case_2_2" end from s3object;')).replace("\n","")
@@ -1332,7 +1333,7 @@ def test_bool_cast_expressions():
     csv_obj = create_random_csv_object(10000,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
     res_s3select_cast = remove_xml_tags_from_result(  run_s3select(bucket_name,csv_obj_name,'select count(*) from s3object where cast(int(_1) as bool) = true ;')).replace("\n","")
@@ -1347,7 +1348,7 @@ def test_progress_expressions():
     csv_obj = create_random_csv_object(1000000,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
     obj_size = len(csv_obj.encode('utf-8'))
@@ -1375,7 +1376,7 @@ def test_output_serial_expressions():
     csv_obj = create_random_csv_object(10000,10)
 
     csv_obj_name = get_random_string()
-    bucket_name = "test"
+    bucket_name = get_new_bucket_name()
     upload_csv_object(bucket_name,csv_obj_name,csv_obj)
 
     res_s3select_1 = remove_xml_tags_from_result(  run_s3select_output(bucket_name,csv_obj_name,"select _1, _2 from s3object where nullif(_1,_2) is null ;", "ALWAYS")  ).replace("\n",",").replace(",","")


### PR DESCRIPTION
S3Select tests uses hard-coded bucket name.
The teardown only deletes bucket with names that start with certain prefix, so the bucket created by these tests remain after test is complete.
Using get_new_bucket_name() instead will auto-delete the new bucket when a test is done.

Signed-off-by: Amit Prinz Setter <aprinzse@redhat.com>