### PR TITLE
QoL: Fix tox.ini syntax and other minor things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@
 
 /*.egg-info
 /virtualenv
+/venv
 
 config.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pytz >=2011k
 httplib2
 lxml
 pytest
+tox

--- a/tox.ini
+++ b/tox.ini
@@ -3,5 +3,7 @@ envlist = py
 
 [testenv]
 deps = -rrequirements.txt
-passenv = S3TEST_CONF S3_USE_SIGV4
+passenv =
+  S3TEST_CONF
+  S3_USE_SIGV4
 commands = pytest {posargs}


### PR DESCRIPTION
- Fix tox.ini syntax

Modern tox versions require the expected environment variables to be listed one by one on separate lines in tox.ini

- Add `venv` to list of ignored names for git

This is a common name for a local Python virtual environment. Less typing than `virtualenv`

- Add `tox` to requirements.txt

Installing `tox` via `pip` has the advantage of including it in the virtual environment, thus avoiding trouble on operating systems shipping by default with python3.6 or older. It's also nice that `pip install -r requirements.txt` is now sufficient to set up the testing environment, after initializing the virtual environment with a moder-enough python version.