### PR TITLE
dbstore: add back missing 'fails_on_dbstore' tag

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -8350,6 +8350,7 @@ def test_lifecycle_expiration_header_tags_head():
 
 @pytest.mark.lifecycle
 @pytest.mark.lifecycle_expiration
+@pytest.mark.fails_on_dbstore
 def test_lifecycle_expiration_header_and_tags_head():
     now = datetime.datetime.now(None)
     bucket_name = get_new_bucket()


### PR DESCRIPTION
Mark testcase "test_lifecycle_expiration_header_and_tags_head" as fails_on_dbstore