### PR TITLE
test_sse_s3_default_multipart_upload verifies encryption header

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -12642,6 +12642,7 @@ def test_sse_s3_default_multipart_upload():
 
     assert response['Metadata'] == metadata
     assert response['ResponseMetadata']['HTTPHeaders']['content-type'] == content_type
+    assert response['ResponseMetadata']['HTTPHeaders']['x-amz-server-side-encryption'] == 'AES256'
 
     body = _get_body(response)
     assert body == data


### PR DESCRIPTION
there's a `test_sse_s3_default_multipart_upload` test case, but it wasn't verifying that the upload was actually encrypted

for https://github.com/ceph/ceph/pull/49409 https://tracker.ceph.com/issues/59218