### PR TITLE
test_encryption_sse_c_unaligned_multipart_upload fails_on_dbstore

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -9367,6 +9367,7 @@ def test_encryption_sse_c_multipart_upload():
         _check_content_using_range_enc(client, bucket_name, key, data, size, partlen + i, enc_headers=enc_headers)
 
 @pytest.mark.encryption
+@pytest.mark.fails_on_dbstore # x-rgw-object-count/bytes-used not implemented
 def test_encryption_sse_c_unaligned_multipart_upload():
     bucket_name = get_new_bucket()
     client = get_client()


### PR DESCRIPTION
fixes a new dbstore failure introduced by https://github.com/ceph/s3-tests/pull/266. `DBBucket::update_container_stats()` is a noop, so the response headers `x-rgw-object-count` and `x-rgw-bytes-used` are not initialized

example: http://qa-proxy.ceph.com/teuthology/soumyakoduri-2023-06-20_12:37:42-rgw-wip-rgw-yield-work-distro-default-smithi/7309055/teuthology.log

