### PR TITLE
Remove filtering from boto3 test example for simplicity

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Once you have that file copied and edited, you can run the tests with::
 
 You can specify which directory of tests to run::
 
-	S3TEST_CONF=your.conf tox s3tests_boto3/functional
+	S3TEST_CONF=your.conf tox -- s3tests_boto3/functional
 
 You can specify which file of tests to run::
 
@@ -44,7 +44,7 @@ located in the ``s3test_boto3`` directory.
 
 You can run only the boto3 tests with::
 
-	S3TEST_CONF=your.conf tox -- -m 'not fails_on_rgw' s3tests_boto3/functional
+	S3TEST_CONF=your.conf tox -- s3tests_boto3/functional
 
 ========================
  STS compatibility tests


### PR DESCRIPTION
having the filter from previous examples might be confusing because It can be interpreted as a needed part to run only boto3 tests. I removed it to make the example as simple as possible