### PR TITLE
boto2: fix byte vs. string comparison in verify_object

### DIFF
--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -362,6 +362,9 @@ def configured_storage_classes():
             if item != 'STANDARD':
                 sc.append(item)
 
+    sc = [i for i in sc if i]
+    print("storage classes configured: " + str(sc))
+
     return sc
 
 def lc_transition(days=None, date=None, storage_class=None):


### PR DESCRIPTION
the storage class tests were failing on comparisons between the input data and output data:
```
AssertionError: assert 'oFbdZvtRj' == b'oFbdZvtRj'
```
convert the byte representation back to string for comparison

Fixes: https://tracker.ceph.com/issues/62919