### PR TITLE
Reflect the correct Error code returned by S3 "NoSuchTagSetError"i

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -7797,7 +7797,7 @@ def test_set_bucket_tagging():
     e = assert_raises(ClientError, client.get_bucket_tagging, Bucket=bucket_name)
     status, error_code = _get_status_and_error_code(e.response)
     eq(status, 404)
-    eq(error_code, 'NoSuchTagSet')
+    eq(error_code, 'NoSuchTagSetError')
 
     client.put_bucket_tagging(Bucket=bucket_name, Tagging=tags)
 
@@ -7810,7 +7810,7 @@ def test_set_bucket_tagging():
     e = assert_raises(ClientError, client.get_bucket_tagging, Bucket=bucket_name)
     status, error_code = _get_status_and_error_code(e.response)
     eq(status, 404)
-    eq(error_code, 'NoSuchTagSet')
+    eq(error_code, 'NoSuchTagSetError')
 
 
 class FakeFile(object):


### PR DESCRIPTION
this should resolve seen on ceph-quincy 

'FAIL: s3tests_boto3.functional.test_s3.test_set_bucket_tagging'
 b'  File "/home/cephuser/s3-tests/s3tests_boto3/functional/test_s3.py", line 7800, in test_set_bucket_tagging'
b"    eq(error_code, 'NoSuchTagSet')"
 b"AssertionError: 'NoSuchTagSetError' != 'NoSuchTagSet'"