### PR TITLE
sse: add config option and test case for default encryption

### DIFF
--- a/s3tests_boto3/functional/__init__.py
+++ b/s3tests_boto3/functional/__init__.py
@@ -215,6 +215,8 @@ def setup():
     if not config.default_ssl_verify:
         urllib3.disable_warnings()
 
+    config.default_encryption = cfg.getboolean('DEFAULT', "default_encryption")
+
     # vars from the main section
     config.main_access_key = cfg.get('s3 main',"access_key")
     config.main_secret_key = cfg.get('s3 main',"secret_key")
@@ -626,6 +628,9 @@ def get_config_endpoint():
 
 def get_config_ssl_verify():
     return config.default_ssl_verify
+
+def get_config_default_encryption():
+    return config.default_encryption
 
 def get_main_aws_access_key():
     return config.main_access_key


### PR DESCRIPTION
if default encryption is enabled globally, test that uploads get encrypted even if not requested by the upload of bucket encryption policy

relates to https://github.com/ceph/ceph/pull/52697