### PR TITLE
Add testing for put_object OPTIONS CORS

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -6692,16 +6692,25 @@ def test_cors_header_option():
 
     _cors_request_and_check(requests.options, obj_url, {'Origin': 'example.origin','Access-Control-Request-Headers':'x-amz-meta-header2','Access-Control-Request-Method':'GET'}, 403, None, None)
 
-def _test_cors_options_presigned_get_object(client):
+def _test_cors_options_presigned_method(client, method, extra_params={}):
     bucket_name = _setup_bucket_object_acl('public-read', 'public-read', client=client)
-    params = {'Bucket': bucket_name, 'Key': 'foo'}
 
-    url = client.generate_presigned_url(ClientMethod='get_object', Params=params, ExpiresIn=100000, HttpMethod='GET')
+    if method == 'get_object':
+        httpMethod = 'GET'
+    elif method == 'put_object':
+        httpMethod = 'PUT'
+    else:
+        raise ValueError('invalid method')
+
+    params = {'Bucket': bucket_name, 'Key': 'foo'}
+    params.update(extra_params)
+
+    url = client.generate_presigned_url(ClientMethod=method, Params=params, ExpiresIn=100000, HttpMethod=httpMethod)
 
     res = requests.options(url, verify=get_config_ssl_verify()).__dict__
     assert res['status_code'] == 400
 
-    allowed_methods = ['GET']
+    allowed_methods = [httpMethod]
     allowed_origins = ['example']
 
     cors_config ={
@@ -6713,13 +6722,59 @@ def _test_cors_options_presigned_get_object(client):
     }
 
     client.put_bucket_cors(Bucket=bucket_name, CORSConfiguration=cors_config)
-    _cors_request_and_check(requests.options, url, {'Origin': 'example', 'Access-Control-Request-Method': 'GET'}, 200, 'example', 'GET')
+    _cors_request_and_check(requests.options, url, {'Origin': 'example', 'Access-Control-Request-Method': httpMethod}, 200, 'example', httpMethod)
 
 def test_cors_presigned_get_object():
-    _test_cors_options_presigned_get_object(client=get_client())
+    _test_cors_options_presigned_method(
+        client=get_client(),
+        method='get_object',
+    )
+
+def test_cors_presigned_get_object_with_acl():
+    _test_cors_options_presigned_method(
+        client=get_client(),
+        method='get_object',
+        extra_params={'ACL': 'Bucket'},
+    )
 
 def test_cors_presigned_get_object_tenant():
-    _test_cors_options_presigned_get_object(client=get_tenant_client())
+    _test_cors_options_presigned_method(
+        client=get_tenant_client(),
+        method='get_object',
+    )
+
+def test_cors_presigned_get_object_tenant_with_acl():
+    _test_cors_options_presigned_method(
+        client=get_tenant_client(),
+        method='get_object',
+        extra_params={'ACL': 'Bucket'},
+    )
+
+def test_cors_presigned_put_object():
+    _test_cors_options_presigned_method(
+        client=get_client(),
+        method='put_object',
+    )
+
+def test_cors_presigned_put_object_with_acl():
+    _test_cors_options_presigned_method(
+        client=get_client(),
+        method='put_object',
+        extra_params={'ACL': 'private'},
+    )
+
+def test_cors_presigned_put_object_tenant():
+    _test_cors_options_presigned_method(
+        client=get_tenant_client(),
+        method='put_object',
+    )
+
+def test_cors_presigned_put_object_tenant_with_acl():
+    _test_cors_options_presigned_method(
+        client=get_tenant_client(),
+        method='put_object',
+        extra_params={'ACL': 'private'},
+    )
 
 @pytest.mark.tagging
 def test_set_bucket_tagging():


### PR DESCRIPTION
This adds testing for put_object OPTIONS CORS
with and without ACL, where with ACL has a
bug being worked on in [1].

[1] https://tracker.ceph.com/issues/64308