### PR TITLE
fixing intermittent lifecycle_expiration_header failures(2!=1) beacause of datetime.now() on different timezone

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -9659,7 +9659,7 @@ def test_lifecycle_expiration_header_put():
     bucket_name = get_new_bucket()
     client = get_client()
 
-    now = datetime.datetime.now(None)
+    now = datetime.datetime.utcnow()
     response = setup_lifecycle_expiration(
         client, bucket_name, 'rule1', 1, 'days1/')
     eq(check_lifecycle_expiration_header(response, now, 'rule1', 1), True)
@@ -9673,7 +9673,7 @@ def test_lifecycle_expiration_header_head():
     bucket_name = get_new_bucket()
     client = get_client()
 
-    now = datetime.datetime.now(None)
+    now = datetime.datetime.utcnow()
     response = setup_lifecycle_expiration(
         client, bucket_name, 'rule1', 1, 'days1/')
 


### PR DESCRIPTION
when the local timezone is not UTC and if it is a day behind, lifecycle_header tests fails with 2 days not equal to 1
so replacing datetime.now() with datetime.utcnow()

failure log: http://magna006.ceph.redhat.com/ceph-qe-logs/Hemanth_Sai/s3tests_lc_failures_debug/s3tests_lc_header_fail_logs

pass log with fix: http://magna006.ceph.redhat.com/ceph-qe-logs/Hemanth_Sai/s3tests_lc_failures_debug/s3tests_lc_header_pass_logs