### PR TITLE
replace datetime.now with datetime.utcnow()

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -8588,7 +8588,7 @@ def test_lifecycle_expiration_header_put():
     bucket_name = get_new_bucket()
     client = get_client()
 
-    now = datetime.datetime.now(None)
+    now = datetime.datetime.utcnow()
     response = setup_lifecycle_expiration(
         client, bucket_name, 'rule1', 1, 'days1/')
     assert check_lifecycle_expiration_header(response, now, 'rule1', 1)
@@ -8600,7 +8600,7 @@ def test_lifecycle_expiration_header_head():
     bucket_name = get_new_bucket()
     client = get_client()
 
-    now = datetime.datetime.now(None)
+    now = datetime.datetime.utcnow()
     response = setup_lifecycle_expiration(
         client, bucket_name, 'rule1', 1, 'days1/')
 
@@ -8671,7 +8671,7 @@ def test_lifecycle_expiration_header_tags_head():
 @pytest.mark.lifecycle_expiration
 @pytest.mark.fails_on_dbstore
 def test_lifecycle_expiration_header_and_tags_head():
-    now = datetime.datetime.now(None)
+    now = datetime.datetime.utcnow()
     bucket_name = get_new_bucket()
     client = get_client()
     lifecycle={


### PR DESCRIPTION
when the local timezone is not UTC and if it is a day behind, lifecycle_header tests fails with 2 days not equal to 1 so replacing datetime.now() with datetime.utcnow()