### PR TITLE
requirements: strict boto3 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 PyYAML
 boto >=2.6.0
-boto3 >=1.0.0
+boto3 >=1.0.0 <=1.24.96
 # botocore-1.28 broke v2 signatures, see https://tracker.ceph.com/issues/58059
 botocore <1.28.0
 munch >=2.0.0


### PR DESCRIPTION
Restrict version for `boto3` library. When installing requirements with following command: `pip install -r requirements.txt` the issue appears:
```
ERROR: s3transfer 0.10.0 has requirement botocore<2.0a.0,>=1.33.2, but you'll have botocore 1.27.96 which is incompatible.
ERROR: boto3 1.34.61 has requirement botocore<1.35.0,>=1.34.61, but you'll have botocore 1.27.96 which is incompatible.
```
Since `boto3` installing the latest version it is incompatible with the older version of `botocore`.

Solution:
Restrict `boto3` to version without compatibility conflicts.