### PR TITLE
requirements: unpin pytz version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ munch >=2.0.0
 gevent >=1.0
 isodate >=0.4.4
 requests >=2.23.0
-pytz >=2011k
+pytz
 httplib2
 lxml
 pytest


### PR DESCRIPTION
was pinned long ago in https://github.com/ceph/s3-tests/commit/48ba5dafc4d61cc98bac96dbcef4767196553f34 to "work around pip 1.4 issue"