### PR TITLE
s3: reenable tenanted bucket policy test

### DIFF
--- a/s3tests.conf.SAMPLE
+++ b/s3tests.conf.SAMPLE
@@ -117,6 +117,9 @@ secret_key = opqrstuvwxyzabcdefghijklmnopqrstuvwxyzab
 # tenant email set in vstart.sh
 email = tenanteduser@example.com
 
+# tenant name
+tenant = testx
+
 #following section needs to be added for all sts-tests
 [iam]
 #used for iam operations in sts-tests

--- a/s3tests_boto3/functional/__init__.py
+++ b/s3tests_boto3/functional/__init__.py
@@ -259,6 +259,7 @@ def configure():
     config.tenant_display_name = cfg.get('s3 tenant',"display_name")
     config.tenant_user_id = cfg.get('s3 tenant',"user_id")
     config.tenant_email = cfg.get('s3 tenant',"email")
+    config.tenant_name = cfg.get('s3 tenant',"tenant")
 
     config.iam_access_key = cfg.get('iam',"access_key")
     config.iam_secret_key = cfg.get('iam',"secret_key")
@@ -693,6 +694,9 @@ def get_tenant_aws_secret_key():
 
 def get_tenant_display_name():
     return config.tenant_display_name
+
+def get_tenant_name():
+    return config.tenant_name
 
 def get_tenant_user_id():
     return config.tenant_user_id


### PR DESCRIPTION
the before-call hook url-encodes the ':' part of tenanted bucket names to resolve SignatureDoesNotMatch errors

removed the list-v2 version of the test since it isn't relevant to bucket policy test coverage

add a new test case that creates the bucket under the tenanted user, then uses the main client to access it