### PR TITLE
Add v2 signature presigned get_object tests

### DIFF
--- a/s3tests_boto3/functional/__init__.py
+++ b/s3tests_boto3/functional/__init__.py
@@ -511,6 +511,17 @@ def get_tenant_client(client_config=None):
                         config=client_config)
     return client
 
+def get_v2_tenant_client():
+    client_config = Config(signature_version='s3')
+    client = boto3.client(service_name='s3',
+                          aws_access_key_id=config.tenant_access_key,
+                          aws_secret_access_key=config.tenant_secret_key,
+                          endpoint_url=config.default_endpoint,
+                          use_ssl=config.default_is_secure,
+                          verify=config.default_ssl_verify,
+                          config=client_config)
+    return client
+
 def get_tenant_iam_client():
 
     client = boto3.client(service_name='iam',

--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -67,6 +67,7 @@ from . import (
     get_alt_email,
     get_alt_client,
     get_tenant_client,
+    get_v2_tenant_client,
     get_tenant_iam_client,
     get_tenant_name,
     get_tenant_user_id,
@@ -6785,6 +6786,18 @@ def test_cors_presigned_get_object():
 def test_cors_presigned_get_object_tenant():
     _test_cors_options_presigned_method(
         client=get_tenant_client(),
+        method='get_object',
+    )
+
+def test_cors_presigned_get_object_v2():
+    _test_cors_options_presigned_method(
+        client=get_v2_client(),
+        method='get_object',
+    )
+
+def test_cors_presigned_get_object_tenant_v2():
+    _test_cors_options_presigned_method(
+        client=get_v2_tenant_client(),
         method='get_object',
     )
 

--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -6814,6 +6814,18 @@ def test_cors_presigned_put_object_with_acl():
         cannedACL='private',
     )
 
+def test_cors_presigned_put_object_v2():
+    _test_cors_options_presigned_method(
+        client=get_v2_client(),
+        method='put_object',
+    )
+
+def test_cors_presigned_put_object_tenant_v2():
+    _test_cors_options_presigned_method(
+        client=get_v2_tenant_client(),
+        method='put_object',
+    )
+
 def test_cors_presigned_put_object_tenant():
     _test_cors_options_presigned_method(
         client=get_tenant_client(),


### PR DESCRIPTION
This adds tests for get_object presigned URLs
using signature v2.

Also code formatting.

This change depends on [1].

[1] https://github.com/ceph/ceph/pull/59977