### PR TITLE
rgw/s3tests: making the tests generic to check only

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -5296,7 +5296,6 @@ def test_list_buckets_invalid_auth():
     e = assert_raises(ClientError, bad_auth_client.list_buckets)
     status, error_code = _get_status_and_error_code(e.response)
     assert status == 403
-    assert error_code == 'InvalidAccessKeyId'
 
 def test_list_buckets_bad_auth():
     main_access_key = get_main_aws_access_key()
@@ -5304,7 +5303,6 @@ def test_list_buckets_bad_auth():
     e = assert_raises(ClientError, bad_auth_client.list_buckets)
     status, error_code = _get_status_and_error_code(e.response)
     assert status == 403
-    assert error_code == 'SignatureDoesNotMatch'
 
 @pytest.fixture
 def override_prefix_a():


### PR DESCRIPTION
for 403 error code (and not specific errors) so that the tests pass for any order of auth engines.