### PR TITLE
Switch from ssl.wrap_socket to SSLContext.wrap_socket

### DIFF
--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -6799,7 +6799,8 @@ def _simple_http_req_100_cont(host, port, is_secure, method, resource):
 
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     if is_secure:
-        s = ssl.wrap_socket(s);
+        ssl_context = ssl.create_default_context()
+        s = ssl_context.wrap_socket(s, server_hostname=host)
     s.settimeout(5)
     s.connect((host, port))
     s.send(req)


### PR DESCRIPTION
The python docs specify that since python 3.2, it is recommended to use `SSLContext.wrap_socket` instead of `ssl.wrap_socket` ("since it is both inefficient and has no support for SNI and hostname matching").

In python3.12, `ssl.wrap_socket` was removed, which causes the 100-continue test to reliably fail whenever it's configured with `is_secure=True`. Switching to the recommended `SSLContext.wrap_socket` (using the default SSL context) fixes this, allowing the test to run cleanly again.