### PR TITLE
rgw/logging: fix test markers

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -8,6 +8,7 @@ markers =
     bucket_policy
     bucket_encryption
     bucket_logging
+    bucket_logging_cleanup
     checksum
     cloud_transition
     encryption
@@ -18,6 +19,7 @@ markers =
     fails_on_rgw
     fails_on_s3
     fails_with_subdomain
+    fails_without_logging_rollover
     group
     group_policy
     iam_account

--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -14778,6 +14778,7 @@ def _put_bucket_logging_tenant(log_type):
 
 @pytest.mark.bucket_logging
 @pytest.mark.fails_on_aws
+@pytest.mark.fails_without_logging_rollover
 def test_put_bucket_logging_tenant_s():
     _put_bucket_logging_tenant('Standard')
 
@@ -14889,16 +14890,22 @@ def _bucket_logging_put_objects(versioned):
 
 
 @pytest.mark.bucket_logging
+@pytest.mark.fails_on_aws
+@pytest.mark.fails_without_logging_rollover
 def test_bucket_logging_put_objects():
     _bucket_logging_put_objects(False)
 
 
 @pytest.mark.bucket_logging
+@pytest.mark.fails_on_aws
+@pytest.mark.fails_without_logging_rollover
 def test_bucket_logging_put_objects_versioned():
     _bucket_logging_put_objects(True)
 
 
 @pytest.mark.bucket_logging
+@pytest.mark.fails_on_aws
+@pytest.mark.fails_without_logging_rollover
 def test_bucket_logging_put_concurrency():
     src_bucket_name = get_new_bucket()
     log_bucket_name = get_new_bucket_name()
@@ -15009,16 +15016,19 @@ def _bucket_logging_delete_objects(versioned):
 
 
 @pytest.mark.bucket_logging
+@pytest.mark.fails_on_aws
+@pytest.mark.fails_without_logging_rollover
 def test_bucket_logging_delete_objects():
     _bucket_logging_delete_objects(False)
 
 
 @pytest.mark.bucket_logging
+@pytest.mark.fails_on_aws
+@pytest.mark.fails_without_logging_rollover
 def test_bucket_logging_delete_objects_versioned():
     _bucket_logging_delete_objects(True)
 
 
-@pytest.mark.bucket_logging
 def _bucket_logging_get_objects(versioned):
     src_bucket_name = get_new_bucket()
     if versioned:
@@ -15072,16 +15082,19 @@ def _bucket_logging_get_objects(versioned):
 
 
 @pytest.mark.bucket_logging
+@pytest.mark.fails_on_aws
+@pytest.mark.fails_without_logging_rollover
 def test_bucket_logging_get_objects():
     _bucket_logging_get_objects(False)
     
 
 @pytest.mark.bucket_logging
+@pytest.mark.fails_on_aws
+@pytest.mark.fails_without_logging_rollover
 def test_bucket_logging_get_objects_versioned():
     _bucket_logging_get_objects(True)
 
 
-@pytest.mark.bucket_logging
 def _bucket_logging_copy_objects(versioned, another_bucket):
     src_bucket_name = get_new_bucket()
     if another_bucket:
@@ -15142,26 +15155,33 @@ def _bucket_logging_copy_objects(versioned, another_bucket):
 
 
 @pytest.mark.bucket_logging
+@pytest.mark.fails_on_aws
+@pytest.mark.fails_without_logging_rollover
 def test_bucket_logging_copy_objects():
     _bucket_logging_copy_objects(False, False)
 
 
 @pytest.mark.bucket_logging
+@pytest.mark.fails_on_aws
+@pytest.mark.fails_without_logging_rollover
 def test_bucket_logging_copy_objects_versioned():
     _bucket_logging_copy_objects(True, False)
 
 
 @pytest.mark.bucket_logging
+@pytest.mark.fails_on_aws
+@pytest.mark.fails_without_logging_rollover
 def test_bucket_logging_copy_objects_bucket():
     _bucket_logging_copy_objects(False, True)
 
 
 @pytest.mark.bucket_logging
+@pytest.mark.fails_on_aws
+@pytest.mark.fails_without_logging_rollover
 def test_bucket_logging_copy_objects_bucket_versioned():
     _bucket_logging_copy_objects(True, True)
 
 
-@pytest.mark.bucket_logging
 def _bucket_logging_head_objects(versioned):
     src_bucket_name = get_new_bucket()
     if versioned:
@@ -15213,16 +15233,19 @@ def _bucket_logging_head_objects(versioned):
 
 
 @pytest.mark.bucket_logging
+@pytest.mark.fails_on_aws
+@pytest.mark.fails_without_logging_rollover
 def test_bucket_logging_head_objects():
     _bucket_logging_head_objects(False)
 
 
 @pytest.mark.bucket_logging
+@pytest.mark.fails_on_aws
+@pytest.mark.fails_without_logging_rollover
 def test_bucket_logging_head_objects_versioned():
     _bucket_logging_head_objects(True)
 
 
-@pytest.mark.bucket_logging
 def _bucket_logging_mpu(versioned):
     src_bucket_name = get_new_bucket()
     if versioned:
@@ -15270,16 +15293,19 @@ def _bucket_logging_mpu(versioned):
 
 
 @pytest.mark.bucket_logging
+@pytest.mark.fails_on_aws
+@pytest.mark.fails_without_logging_rollover
 def test_bucket_logging_mpu():
     _bucket_logging_mpu(False)
 
 
 @pytest.mark.bucket_logging
+@pytest.mark.fails_on_aws
+@pytest.mark.fails_without_logging_rollover
 def test_bucket_logging_mpu_versioned():
     _bucket_logging_mpu(True)
 
 
-@pytest.mark.bucket_logging
 def _bucket_logging_mpu_copy(versioned):
     src_bucket_name = get_new_bucket()
     if versioned:
@@ -15324,11 +15350,15 @@ def _bucket_logging_mpu_copy(versioned):
 
 
 @pytest.mark.bucket_logging
+@pytest.mark.fails_on_aws
+@pytest.mark.fails_without_logging_rollover
 def test_bucket_logging_mpu_copy():
     _bucket_logging_mpu_copy(False)
 
 
 @pytest.mark.bucket_logging
+@pytest.mark.fails_on_aws
+@pytest.mark.fails_without_logging_rollover
 def test_bucket_logging_mpu_copy_versioned():
     _bucket_logging_mpu_copy(True)
 
@@ -15393,11 +15423,15 @@ def _bucket_logging_multi_delete(versioned):
 
 
 @pytest.mark.bucket_logging
+@pytest.mark.fails_on_aws
+@pytest.mark.fails_without_logging_rollover
 def test_bucket_logging_multi_delete():
     _bucket_logging_multi_delete(False)
 
 
 @pytest.mark.bucket_logging
+@pytest.mark.fails_on_aws
+@pytest.mark.fails_without_logging_rollover
 def test_bucket_logging_multi_delete_versioned():
     _bucket_logging_multi_delete(True)
 
@@ -15534,6 +15568,8 @@ def test_bucket_logging_roll_time():
 
 
 @pytest.mark.bucket_logging
+@pytest.mark.fails_on_aws
+@pytest.mark.fails_without_logging_rollover
 def test_bucket_logging_multiple_prefixes():
     log_bucket_name = get_new_bucket_name()
     log_bucket = get_new_bucket_resource(name=log_bucket_name)
@@ -15582,6 +15618,8 @@ def test_bucket_logging_multiple_prefixes():
 
 
 @pytest.mark.bucket_logging
+@pytest.mark.fails_on_aws
+@pytest.mark.fails_without_logging_rollover
 def test_bucket_logging_single_prefix():
     log_bucket_name = get_new_bucket_name()
     log_bucket = get_new_bucket_resource(name=log_bucket_name)


### PR DESCRIPTION
* add marker to indicate tests that require rollover time configuration
* update tests that fail on aws
* remove markers from utility functions

this is to address this comment:
https://github.com/ceph/ceph/pull/61486#issuecomment-2607695183