### PR TITLE
rgw/s3tests: removing fails_on_rgw for

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -8115,8 +8115,6 @@ def _do_clear_versioned_bucket_concurrent(client, bucket_name):
         t.append(thr)
     return t
 
-# TODO: remove fails_on_rgw when https://tracker.ceph.com/issues/39142 is resolved
-@pytest.mark.fails_on_rgw
 def test_versioned_concurrent_object_create_concurrent_remove():
     bucket_name = get_new_bucket()
     client = get_client()


### PR DESCRIPTION
test_versioned_concurrent_object_create_concurrent_remove as the associated tracker is marked as resolved and the test also passes against main.