### PR TITLE
test put_bucket_acl with group uri

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -4068,6 +4068,41 @@ def test_bucket_acl_canned_authenticatedread():
             ],
         )
 
+def test_put_bucket_acl_grant_group_read():
+    bucket_name = get_new_bucket()
+    client = get_client()
+    display_name = get_main_display_name()
+    user_id = get_main_user_id()
+
+    grant = {'Grantee': {'Type': 'Group', 'URI': 'http://acs.amazonaws.com/groups/global/AllUsers'}, 'Permission': 'READ'}
+    policy = add_bucket_user_grant(bucket_name, grant)
+
+    client.put_bucket_acl(Bucket=bucket_name, AccessControlPolicy=policy)
+
+    response = client.get_bucket_acl(Bucket=bucket_name)
+
+    check_grants(
+        response['Grants'],
+        [
+            dict(
+                Permission='READ',
+                ID=None,
+                DisplayName=None,
+                URI='http://acs.amazonaws.com/groups/global/AllUsers',
+                EmailAddress=None,
+                Type='Group',
+                ),
+            dict(
+                Permission='FULL_CONTROL',
+                ID=user_id,
+                DisplayName=display_name,
+                URI=None,
+                EmailAddress=None,
+                Type='CanonicalUser',
+                ),
+            ],
+        )
+
 def test_object_acl_default():
     bucket_name = get_new_bucket()
     client = get_client()


### PR DESCRIPTION
test case for https://github.com/ceph/ceph/pull/61368 / https://tracker.ceph.com/issues/69527

fails without:
> FAILED s3tests_boto3/functional/test_s3.py::test_put_bucket_acl_grant_group_read - botocore.exceptions.ClientError: An error occurred (InvalidArgument) when calling the PutBucketAcl operation: Invalid group uri

passes with:
> s3tests_boto3/functional/test_s3.py::test_put_bucket_acl_grant_group_read PASSED