### PR TITLE
s3: avoid 100-continue bug for test_encryption_sse_c_deny_algo_with_bucket_policy

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -10689,7 +10689,7 @@ def test_encryption_sse_c_deny_algo_with_bucket_policy():
 
     client.put_bucket_policy(Bucket=bucket_name, Policy=policy_document)
 
-    check_access_denied(client.put_object, Bucket=bucket_name, Key='foo', Body='bar', SSECustomerAlgorithm='AES192')
+    check_access_denied(client.put_object, Bucket=bucket_name, Key='foo', SSECustomerAlgorithm='AES192')
 
     client.put_object(
         Bucket=bucket_name, Key='foo', Body='bar',


### PR DESCRIPTION
was failing for a reason unrelated to sse-c or bucket policy. add a separate test case `test_100_continue_error_retry` that exercises the 100-continue issue directly, and mark fails_on_rgw

Fixes: https://tracker.ceph.com/issues/70607