### PR TITLE
add missing 'assert' to test_bucket_logging_roll_time

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -16618,7 +16618,7 @@ def test_bucket_logging_roll_time():
 
     response = client.list_objects_v2(Bucket=log_bucket_name)
     keys = _get_keys(response)
-    len(keys) == 1
+    assert len(keys) == 1
 
     key = keys[0]
     assert key.startswith('log/')


### PR DESCRIPTION
saw a failure after this:
```
        response = client.list_objects_v2(Bucket=log_bucket_name)
        keys = _get_keys(response)
        len(keys) == 1

>       key = keys[0]
E       IndexError: list index out of range

s3tests_boto3/functional/test_s3.py:16637: IndexError
```