### PR TITLE
s3control: add test_account_public_access_block()

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -39,6 +39,7 @@ markers =
     object_ownership
     role_policy
     session_policy
+    s3control
     s3select
     s3website
     s3website_routing_rules

--- a/s3tests.conf.SAMPLE
+++ b/s3tests.conf.SAMPLE
@@ -150,6 +150,7 @@ display_name = youruseridhere
 [iam root]
 access_key = AAAAAAAAAAAAAAAAAAaa
 secret_key = aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+account_id = RGW11111111111111111
 user_id = RGW11111111111111111
 email = account1@ceph.com
 
@@ -157,6 +158,7 @@ email = account1@ceph.com
 [iam alt root]
 access_key = BBBBBBBBBBBBBBBBBBbb
 secret_key = bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+account_id = RGW22222222222222222
 user_id = RGW22222222222222222
 email = account2@ceph.com
 

--- a/s3tests/functional/__init__.py
+++ b/s3tests/functional/__init__.py
@@ -221,6 +221,7 @@ def configure():
     config.main_display_name = cfg.get('s3 main',"display_name")
     config.main_user_id = cfg.get('s3 main',"user_id")
     config.main_email = cfg.get('s3 main',"email")
+    config.main_account_id = cfg.get('s3 main', 'account_id', fallback=None)
     try:
         config.main_kms_keyid = cfg.get('s3 main',"kms_keyid")
     except (configparser.NoSectionError, configparser.NoOptionError):
@@ -263,12 +264,14 @@ def configure():
     config.alt_display_name = cfg.get('s3 alt',"display_name")
     config.alt_user_id = cfg.get('s3 alt',"user_id")
     config.alt_email = cfg.get('s3 alt',"email")
+    config.alt_account_id = cfg.get('s3 alt', 'account_id', fallback=None)
 
     config.tenant_access_key = cfg.get('s3 tenant',"access_key")
     config.tenant_secret_key = cfg.get('s3 tenant',"secret_key")
     config.tenant_display_name = cfg.get('s3 tenant',"display_name")
     config.tenant_user_id = cfg.get('s3 tenant',"user_id")
     config.tenant_email = cfg.get('s3 tenant',"email")
+    config.tenant_account_id = cfg.get('s3 tenant', 'account_id', fallback=None)
     config.tenant_name = cfg.get('s3 tenant',"tenant")
 
     config.iam_access_key = cfg.get('iam',"access_key")
@@ -281,11 +284,13 @@ def configure():
     config.iam_root_secret_key = cfg.get('iam root',"secret_key")
     config.iam_root_user_id = cfg.get('iam root',"user_id")
     config.iam_root_email = cfg.get('iam root',"email")
+    config.iam_root_account_id = cfg.get('iam root', 'account_id', fallback=None)
 
     config.iam_alt_root_access_key = cfg.get('iam alt root',"access_key")
     config.iam_alt_root_secret_key = cfg.get('iam alt root',"secret_key")
     config.iam_alt_root_user_id = cfg.get('iam alt root',"user_id")
     config.iam_alt_root_email = cfg.get('iam alt root',"email")
+    config.iam_alt_root_account_id = cfg.get('iam alt root', 'account_id', fallback=None)
 
     # vars from the fixtures section
     template = cfg.get('fixtures', "bucket prefix", fallback='test-{random}-')
@@ -715,6 +720,9 @@ def get_main_user_id():
 def get_main_email():
     return config.main_email
 
+def get_main_account_id():
+    return config.main_account_id
+
 def get_main_api_name():
     return config.main_api_name
 
@@ -736,6 +744,9 @@ def get_alt_display_name():
 def get_alt_user_id():
     return config.alt_user_id
 
+def get_alt_account_id():
+    return config.alt_account_id
+
 def get_alt_email():
     return config.alt_email
 
@@ -747,6 +758,9 @@ def get_tenant_aws_secret_key():
 
 def get_tenant_display_name():
     return config.tenant_display_name
+
+def get_tenant_account_id():
+    return config.tenant_account_id
 
 def get_tenant_name():
     return config.tenant_name
@@ -796,11 +810,17 @@ def get_iam_root_user_id():
 def get_iam_root_email():
     return config.iam_root_email
 
+def get_iam_root_account_id():
+    return config.iam_root_account_id
+
 def get_iam_alt_root_user_id():
     return config.iam_alt_root_user_id
 
 def get_iam_alt_root_email():
     return config.iam_alt_root_email
+
+def get_iam_alt_root_account_id():
+    return config.iam_alt_root_account_id
 
 def get_user_token():
     return config.webidentity_user_token

--- a/s3tests/functional/test_iam.py
+++ b/s3tests/functional/test_iam.py
@@ -13,9 +13,11 @@ from . import (
     get_alt_client,
     get_iam_client,
     get_iam_root_client,
+    get_iam_root_account_id,
     get_iam_alt_root_client,
     get_iam_alt_root_user_id,
     get_iam_alt_root_email,
+    get_iam_alt_root_account_id,
     make_iam_name,
     get_iam_path_prefix,
     get_new_bucket,
@@ -2363,8 +2365,7 @@ def test_account_role_policy_allow_create_bucket(iam_root, iam_alt_root):
     s3_main = get_iam_root_client(service_name='s3')
     response = s3_main.get_bucket_acl(Bucket=bucket_name)
 
-    main_arn = iam_root.get_user()['User']['Arn']
-    account_id = main_arn.removeprefix('arn:aws:iam::').removesuffix(':root')
+    account_id = get_iam_root_account_id()
     assert response['Owner']['ID'] == account_id
     assert response['Grants'][0]['Grantee']['ID'] == account_id
 
@@ -2757,9 +2758,9 @@ def test_cross_account_user_bucket_policy_allow_account_id(iam_root, iam_alt_roo
     roots3 = get_iam_root_client(service_name='s3')
     path = get_iam_path_prefix()
     user_name = make_iam_name('AltUser')
-    response = iam_alt_root.create_user(UserName=user_name, Path=path)
-    user_arn = response['User']['Arn']
-    account_id = user_arn.removeprefix('arn:aws:iam::').removesuffix(f':user{path}{user_name}')
+    iam_alt_root.create_user(UserName=user_name, Path=path)
+
+    account_id = get_iam_alt_root_account_id()
     _test_cross_account_user_bucket_policy(roots3, iam_alt_root, user_name, account_id)
 
 @pytest.mark.iam_account
@@ -2768,9 +2769,9 @@ def test_cross_account_bucket_user_policy_allow_account_id(iam_root, iam_alt_roo
     roots3 = get_iam_root_client(service_name='s3')
     path = get_iam_path_prefix()
     user_name = make_iam_name('AltUser')
-    response = iam_alt_root.create_user(UserName=user_name, Path=path)
-    user_arn = response['User']['Arn']
-    account_id = user_arn.removeprefix('arn:aws:iam::').removesuffix(f':user{path}{user_name}')
+    iam_alt_root.create_user(UserName=user_name, Path=path)
+
+    account_id = get_iam_alt_root_account_id()
     _test_cross_account_bucket_user_policy(roots3, iam_alt_root, user_name, account_id)
 
 
@@ -2944,8 +2945,8 @@ def test_cross_account_root_bucket_policy_allow_account_arn(iam_root, iam_alt_ro
 def test_cross_account_root_bucket_policy_allow_account_id(iam_root, iam_alt_root):
     roots3 = get_iam_root_client(service_name='s3')
     alts3 = get_iam_alt_root_client(service_name='s3')
-    alt_arn = iam_alt_root.get_user()['User']['Arn']
-    account_id = alt_arn.removeprefix('arn:aws:iam::').removesuffix(':root')
+
+    account_id = get_iam_alt_root_account_id()
     _test_cross_account_root_bucket_policy(roots3, alts3, account_id)
 
 # test root cross-account access with bucket acls

--- a/s3tests/functional/test_s3control.py
+++ b/s3tests/functional/test_s3control.py
@@ -1,0 +1,90 @@
+import boto3
+from botocore.exceptions import ClientError
+import json
+import pytest
+
+from . import (
+    configfile,
+    setup_teardown,
+    get_iam_root_client,
+    get_iam_root_account_id,
+    get_new_bucket_name,
+    )
+from .utils import (
+    assert_raises,
+    _get_status_and_error_code,
+    )
+
+@pytest.mark.s3control
+def test_account_public_access_block():
+    s3control = get_iam_root_client(service_name='s3control', region_name='us-east-1')
+    account_id = get_iam_root_account_id()
+
+    # delete default configuration if it exists
+    response = s3control.delete_public_access_block(AccountId=account_id)
+    assert response['ResponseMetadata']['HTTPStatusCode'] == 204
+    # re-delete should still return 204
+    response = s3control.delete_public_access_block(AccountId=account_id)
+    assert response['ResponseMetadata']['HTTPStatusCode'] == 204
+
+    # get returns 404
+    e = assert_raises(ClientError, s3control.get_public_access_block, AccountId=account_id)
+    assert (404, 'NoSuchPublicAccessBlockConfiguration') == _get_status_and_error_code(e.response)
+
+    s3control.put_public_access_block(
+            AccountId=account_id,
+            PublicAccessBlockConfiguration={
+                'BlockPublicAcls': True,
+                'IgnorePublicAcls': False,
+                'BlockPublicPolicy': False,
+                'RestrictPublicBuckets': False
+            })
+    try:
+        response = s3control.get_public_access_block(AccountId=account_id)
+        assert response['PublicAccessBlockConfiguration']['BlockPublicAcls']
+        assert not response['PublicAccessBlockConfiguration']['IgnorePublicAcls']
+        assert not response['PublicAccessBlockConfiguration']['BlockPublicPolicy']
+        assert not response['PublicAccessBlockConfiguration']['RestrictPublicBuckets']
+
+        s3 = get_iam_root_client(service_name='s3')
+        bucket = get_new_bucket_name()
+
+        # reject CreateBucket with public acls
+        e = assert_raises(ClientError, s3.create_bucket, Bucket=bucket, ACL='public-read')
+        assert (403, 'AccessDenied') == _get_status_and_error_code(e.response)
+
+        s3.create_bucket(Bucket=bucket)
+        try:
+            # reject PutBucketAcl with public acls
+            e = assert_raises(ClientError, s3.put_bucket_acl, Bucket=bucket, ACL='public-read')
+            assert (403, 'AccessDenied') == _get_status_and_error_code(e.response)
+
+            # test interaction with bucket-level configuration
+            s3.put_public_access_block(
+                    Bucket=bucket,
+                    PublicAccessBlockConfiguration={
+                        'BlockPublicAcls': False,
+                        'IgnorePublicAcls': False,
+                        'BlockPublicPolicy': True,
+                        'RestrictPublicBuckets': False
+                    })
+            public_policy = json.dumps({
+                "Version": "2012-10-17",
+                "Statement": [{
+                    "Effect": "Allow",
+                    "Principal": {"AWS": "*"},
+                    "Action": "*",
+                    "Resource": [
+                        f"arn:aws:s3:::{bucket}",
+                        f"arn:aws:s3:::{bucket}/*"
+                    ]
+                }]
+            })
+            # reject PutBucketPolicy with public policy based on bucket config
+            e = assert_raises(ClientError, s3.put_bucket_policy,
+                              Bucket=bucket, Policy=public_policy)
+            assert (403, 'AccessDenied') == _get_status_and_error_code(e.response)
+        finally:
+            s3.delete_bucket(Bucket=bucket)
+    finally:
+        s3control.delete_public_access_block(AccountId=account_id)


### PR DESCRIPTION
test s3control Put/Get/DeletePublicAccessBlock and interactions with s3 PutBucketPublicAccessBlock

includes https://github.com/ceph/s3-tests/pull/636 for convenient access to the account id