### PR TITLE
delete, rgwlc: delete marker tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -54,3 +54,4 @@ markers =
     user_policy
     versioning
     webidentity_test
+    delete_marker


### PR DESCRIPTION
0. non-creation in non-versioned buckets
1. creation in versioned buckets
2. creation in versioning-suspended buckets
3. delete-marker expiration (lifecycle)