### PR TITLE
s3: test conditional put_object() and delete_object()

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,7 @@ markers =
     bucket_encryption
     bucket_logging
     bucket_logging_cleanup
+    conditional_write
     fails_without_logging_rollover
     checksum
     cloud_transition

--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -18351,3 +18351,91 @@ def test_put_object_current_if_match():
     assert (404, 'NoSuchKey') == _get_status_and_error_code(e.response)
 
     client.put_object(Bucket=bucket, Key=key, IfNoneMatch=etag)
+
+@pytest.mark.fails_on_aws # only supported for directory buckets
+@pytest.mark.conditional_write
+def test_delete_object_if_match():
+    client = get_client()
+    bucket = get_new_bucket(client)
+    key = 'obj'
+
+    etag = client.put_object(Bucket=bucket, Key=key)['ETag']
+
+    e = assert_raises(ClientError, client.delete_object, Bucket=bucket, Key=key, IfMatch='badetag')
+    assert (412, 'PreconditionFailed') == _get_status_and_error_code(e.response)
+
+    client.delete_object(Bucket=bucket, Key=key, IfMatch=etag)
+
+    e = assert_raises(ClientError, client.delete_object, Bucket=bucket, Key=key, IfMatch='*')
+    assert (404, 'NoSuchKey') == _get_status_and_error_code(e.response)
+    e = assert_raises(ClientError, client.delete_object, Bucket=bucket, Key=key, IfMatch='badetag')
+    assert (404, 'NoSuchKey') == _get_status_and_error_code(e.response)
+
+    # recreate to test IfMatch='*'
+    client.put_object(Bucket=bucket, Key=key)
+    client.delete_object(Bucket=bucket, Key=key, IfMatch='*')
+
+@pytest.mark.fails_on_aws # only supported for directory buckets
+@pytest.mark.conditional_write
+def test_delete_object_current_if_match():
+    client = get_client()
+    bucket = get_new_bucket(client)
+    check_configure_versioning_retry(bucket, "Enabled", "Enabled")
+    key = 'obj'
+
+    # on nonexistent object
+    e = assert_raises(ClientError, client.delete_object, Bucket=bucket, Key=key, IfMatch='*')
+    assert (404, 'NoSuchKey') == _get_status_and_error_code(e.response)
+    e = assert_raises(ClientError, client.delete_object, Bucket=bucket, Key=key, IfMatch='badetag')
+    assert (404, 'NoSuchKey') == _get_status_and_error_code(e.response)
+
+    response = client.put_object(Bucket=bucket, Key=key)
+    version = response['VersionId']
+    etag = response['ETag']
+
+    # on current version
+    e = assert_raises(ClientError, client.delete_object, Bucket=bucket, Key=key, IfMatch='badetag')
+    assert (412, 'PreconditionFailed') == _get_status_and_error_code(e.response)
+
+    response = client.delete_object(Bucket=bucket, Key=key, IfMatch=etag)
+    assert response['DeleteMarker']
+
+    # on current delete marker
+    e = assert_raises(ClientError, client.delete_object, Bucket=bucket, Key=key, IfMatch='*')
+    assert (404, 'NoSuchKey') == _get_status_and_error_code(e.response)
+    e = assert_raises(ClientError, client.delete_object, Bucket=bucket, Key=key, IfMatch='badetag')
+    assert (404, 'NoSuchKey') == _get_status_and_error_code(e.response)
+
+    # remove delete marker to retest IfMatch='*'
+    client.delete_object(Bucket=bucket, Key=key, VersionId=version)
+    client.delete_object(Bucket=bucket, Key=key, IfMatch='*')
+
+@pytest.mark.fails_on_aws # only supported for directory buckets
+@pytest.mark.conditional_write
+def test_delete_object_version_if_match():
+    client = get_client()
+    bucket = get_new_bucket(client)
+    check_configure_versioning_retry(bucket, "Enabled", "Enabled")
+    key = 'obj'
+
+    response = client.put_object(Bucket=bucket, Key=key)
+    version = response['VersionId']
+    etag = response['ETag']
+
+    # on specific version
+    e = assert_raises(ClientError, client.delete_object, Bucket=bucket, Key=key, VersionId=version, IfMatch='badetag')
+    assert (412, 'PreconditionFailed') == _get_status_and_error_code(e.response)
+
+    response = client.delete_object(Bucket=bucket, Key=key, VersionId=version, IfMatch=etag)
+    assert not response['DeleteMarker']
+
+    # on nonexistent version
+    e = assert_raises(ClientError, client.delete_object, Bucket=bucket, Key=key, VersionId=version, IfMatch='*')
+    assert (404, 'NoSuchKey') == _get_status_and_error_code(e.response)
+    e = assert_raises(ClientError, client.delete_object, Bucket=bucket, Key=key, VersionId=version, IfMatch='badetag')
+    assert (404, 'NoSuchKey') == _get_status_and_error_code(e.response)
+
+    # recreate to test IfMatch='*'
+    response = client.put_object(Bucket=bucket, Key=key)
+    version = response['VersionId']
+    client.delete_object(Bucket=bucket, Key=key, VersionId=version, IfMatch='*')

--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -18567,3 +18567,63 @@ def test_delete_object_version_if_match_size():
 
     e = assert_raises(ClientError, client.delete_object, Bucket=bucket, Key=key, VersionId=version, IfMatchSize=badsize)
     assert (404, 'NoSuchKey') == _get_status_and_error_code(e.response)
+
+@pytest.mark.fails_on_aws # only supported for directory buckets
+@pytest.mark.conditional_write
+def test_delete_objects_if_match():
+    client = get_client()
+    bucket = get_new_bucket(client)
+    key = 'obj'
+
+    etag = client.put_object(Bucket=bucket, Key=key)['ETag']
+
+    response = client.delete_objects(Bucket=bucket, Delete={'Objects': [{'Key': key, 'ETag': 'badetag'}]})
+    assert 'PreconditionFailed' == response['Errors'][0]['Code']
+
+    response = client.delete_objects(Bucket=bucket, Delete={'Objects': [{'Key': key, 'ETag': etag}]})
+    assert key == response['Deleted'][0]['Key'] # success
+
+    response = client.delete_objects(Bucket=bucket, Delete={'Objects': [{'Key': key, 'ETag': 'badetag'}]})
+    assert 'NoSuchKey' == response['Errors'][0]['Code']
+
+@pytest.mark.fails_on_aws # only supported for directory buckets
+@pytest.mark.conditional_write
+def test_delete_objects_current_if_match():
+    client = get_client()
+    bucket = get_new_bucket(client)
+    check_configure_versioning_retry(bucket, "Enabled", "Enabled")
+    key = 'obj'
+
+    etag = client.put_object(Bucket=bucket, Key=key)['ETag']
+
+    response = client.delete_objects(Bucket=bucket, Delete={'Objects': [{'Key': key, 'ETag': 'badetag'}]})
+    assert 'PreconditionFailed' == response['Errors'][0]['Code']
+
+    response = client.delete_objects(Bucket=bucket, Delete={'Objects': [{'Key': key, 'ETag': etag}]})
+    assert key == response['Deleted'][0]['Key'] # success
+    assert response['Deleted'][0]['DeleteMarker']
+
+    response = client.delete_objects(Bucket=bucket, Delete={'Objects': [{'Key': key, 'ETag': 'badetag'}]})
+    assert 'NoSuchKey' == response['Errors'][0]['Code']
+
+@pytest.mark.fails_on_aws # only supported for directory buckets
+@pytest.mark.conditional_write
+def test_delete_objects_version_if_match():
+    client = get_client()
+    bucket = get_new_bucket(client)
+    check_configure_versioning_retry(bucket, "Enabled", "Enabled")
+    key = 'obj'
+
+    response = client.put_object(Bucket=bucket, Key=key)
+    etag = response['ETag']
+    version = response['VersionId']
+
+    response = client.delete_objects(Bucket=bucket, Delete={'Objects': [{'Key': key, 'VersionId': version, 'ETag': 'badetag'}]})
+    assert 'PreconditionFailed' == response['Errors'][0]['Code']
+
+    response = client.delete_objects(Bucket=bucket, Delete={'Objects': [{'Key': key, 'VersionId': version, 'ETag': etag}]})
+    assert key == response['Deleted'][0]['Key'] # success
+    assert not response['Deleted'][0]['DeleteMarker']
+
+    response = client.delete_objects(Bucket=bucket, Delete={'Objects': [{'Key': key, 'VersionId': version, 'ETag': 'badetag'}]})
+    assert 'NoSuchKey' == response['Errors'][0]['Code']

--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -18302,3 +18302,52 @@ def test_delete_marker_expiration():
     # delete marker should have expired
     check_delete_marker(client, bucket, key, 'false')
 
+@pytest.mark.conditional_write
+def test_put_object_if_match():
+    client = get_client()
+    bucket = get_new_bucket(client)
+    key = 'obj'
+
+    etag = client.put_object(Bucket=bucket, Key=key, IfNoneMatch='*')['ETag']
+
+    e = assert_raises(ClientError, client.put_object, Bucket=bucket, Key=key, IfNoneMatch='*')
+    assert (412, 'PreconditionFailed') == _get_status_and_error_code(e.response)
+    e = assert_raises(ClientError, client.put_object, Bucket=bucket, Key=key, IfNoneMatch=etag)
+    assert (412, 'PreconditionFailed') == _get_status_and_error_code(e.response)
+
+    client.put_object(Bucket=bucket, Key=key, IfMatch=etag)
+
+    client.delete_object(Bucket=bucket, Key=key)
+
+    e = assert_raises(ClientError, client.put_object, Bucket=bucket, Key=key, IfMatch='*')
+    assert (404, 'NoSuchKey') == _get_status_and_error_code(e.response)
+    e = assert_raises(ClientError, client.put_object, Bucket=bucket, Key=key, IfMatch='badetag')
+    assert (404, 'NoSuchKey') == _get_status_and_error_code(e.response)
+
+    client.put_object(Bucket=bucket, Key=key, IfNoneMatch=etag)
+
+@pytest.mark.conditional_write
+def test_put_object_current_if_match():
+    client = get_client()
+    bucket = get_new_bucket(client)
+    check_configure_versioning_retry(bucket, "Enabled", "Enabled")
+    key = 'obj'
+
+    etag = client.put_object(Bucket=bucket, Key=key, IfNoneMatch='*')['ETag']
+
+    e = assert_raises(ClientError, client.put_object, Bucket=bucket, Key=key, IfNoneMatch='*')
+    assert (412, 'PreconditionFailed') == _get_status_and_error_code(e.response)
+    e = assert_raises(ClientError, client.put_object, Bucket=bucket, Key=key, IfNoneMatch=etag)
+    assert (412, 'PreconditionFailed') == _get_status_and_error_code(e.response)
+
+    client.put_object(Bucket=bucket, Key=key, IfMatch=etag)
+
+    response = client.delete_object(Bucket=bucket, Key=key)
+    assert response['DeleteMarker']
+
+    e = assert_raises(ClientError, client.put_object, Bucket=bucket, Key=key, IfMatch='*')
+    assert (404, 'NoSuchKey') == _get_status_and_error_code(e.response)
+    e = assert_raises(ClientError, client.put_object, Bucket=bucket, Key=key, IfMatch='badetag')
+    assert (404, 'NoSuchKey') == _get_status_and_error_code(e.response)
+
+    client.put_object(Bucket=bucket, Key=key, IfNoneMatch=etag)

--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -18314,6 +18314,8 @@ def test_put_object_if_match():
     assert (412, 'PreconditionFailed') == _get_status_and_error_code(e.response)
     e = assert_raises(ClientError, client.put_object, Bucket=bucket, Key=key, IfNoneMatch=etag)
     assert (412, 'PreconditionFailed') == _get_status_and_error_code(e.response)
+    response = client.put_object(Bucket=bucket, Key=key, IfNoneMatch='badetag')
+    assert 200 == response['ResponseMetadata']['HTTPStatusCode']
 
     client.put_object(Bucket=bucket, Key=key, IfMatch=etag)
 
@@ -18324,7 +18326,72 @@ def test_put_object_if_match():
     e = assert_raises(ClientError, client.put_object, Bucket=bucket, Key=key, IfMatch='badetag')
     assert (404, 'NoSuchKey') == _get_status_and_error_code(e.response)
 
-    client.put_object(Bucket=bucket, Key=key, IfNoneMatch=etag)
+    response = client.put_object(Bucket=bucket, Key=key, IfNoneMatch=etag)
+    assert 200 == response['ResponseMetadata']['HTTPStatusCode']
+    response = client.put_object(Bucket=bucket, Key=key, IfMatch='*')
+    assert 200 == response['ResponseMetadata']['HTTPStatusCode']
+    e = assert_raises(ClientError, client.put_object, Bucket=bucket, Key=key, IfMatch='badetag')
+    assert (412, 'PreconditionFailed') == _get_status_and_error_code(e.response)
+    response = client.put_object(Bucket=bucket, Key=key, IfMatch=etag)
+    assert 200 == response['ResponseMetadata']['HTTPStatusCode']
+
+@pytest.mark.conditional_write
+def test_put_current_object_if_none_match():
+    client = get_client()
+    bucket = get_new_bucket(client)
+    check_configure_versioning_retry(bucket, "Enabled", "Enabled")
+    key = 'obj'
+    data1 = 'data1'
+    data2 = 'data2'
+
+    response = client.put_object(Bucket=bucket, Key=key, Body=data1, IfNoneMatch='*')
+    etag = response['ETag']
+
+    response = client.put_object(Bucket=bucket, Key=key, Body=data2)
+    etag2 = response['ETag']
+
+    e = assert_raises(ClientError, client.put_object, Bucket=bucket, Key=key, IfNoneMatch='*')
+    assert (412, 'PreconditionFailed') == _get_status_and_error_code(e.response)
+    e = assert_raises(ClientError, client.put_object, Bucket=bucket, Key=key, IfNoneMatch=etag2)
+    assert (412, 'PreconditionFailed') == _get_status_and_error_code(e.response)
+
+    # we can't specify a version, so we only check against current object
+    response = client.put_object(Bucket=bucket, Key=key, IfNoneMatch=etag)
+    assert 200 == response['ResponseMetadata']['HTTPStatusCode']
+    response = client.put_object(Bucket=bucket, Key=key, IfNoneMatch='badetag')
+    assert 200 == response['ResponseMetadata']['HTTPStatusCode']
+
+    client.delete_object(Bucket=bucket, Key=key)
+
+@pytest.mark.conditional_write
+def test_put_current_object_if_match():
+    client = get_client()
+    bucket = get_new_bucket(client)
+    check_configure_versioning_retry(bucket, "Enabled", "Enabled")
+    key = 'obj'
+    data1 = 'data1'
+    data2 = 'data2'
+    etag = 'deadbeef'
+
+    e = assert_raises(ClientError, client.put_object, Bucket=bucket, Key=key, IfMatch='*')
+    assert (404, 'NoSuchKey') == _get_status_and_error_code(e.response)
+    e = assert_raises(ClientError, client.put_object, Bucket=bucket, Key=key, IfMatch='badetag')
+    assert (404, 'NoSuchKey') == _get_status_and_error_code(e.response)
+
+    response = client.put_object(Bucket=bucket, Key=key, Body=data1, IfNoneMatch=etag)
+    assert 200 == response['ResponseMetadata']['HTTPStatusCode']
+    etag = response['ETag']
+    versionId = response['VersionId']
+    response = client.put_object(Bucket=bucket, Key=key, Body=data2, IfMatch='*')
+    assert 200 == response['ResponseMetadata']['HTTPStatusCode']
+    etag2 = response['ETag']
+
+    e = assert_raises(ClientError, client.put_object, Bucket=bucket, Key=key, IfMatch='badetag')
+    assert (412, 'PreconditionFailed') == _get_status_and_error_code(e.response)
+    e = assert_raises(ClientError, client.put_object, Bucket=bucket, Key=key, IfMatch=etag)
+    assert (412, 'PreconditionFailed') == _get_status_and_error_code(e.response)
+    response = client.put_object(Bucket=bucket, Key=key, IfMatch=etag2)
+    assert 200 == response['ResponseMetadata']['HTTPStatusCode']
 
 @pytest.mark.conditional_write
 def test_put_object_current_if_match():

--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -18503,3 +18503,67 @@ def test_delete_object_version_if_match_last_modified_time():
 
     e = assert_raises(ClientError, client.delete_object, Bucket=bucket, Key=key, VersionId=version, IfMatchLastModifiedTime=badmtime)
     assert (404, 'NoSuchKey') == _get_status_and_error_code(e.response)
+
+@pytest.mark.fails_on_aws # only supported for directory buckets
+@pytest.mark.conditional_write
+def test_delete_object_if_match_size():
+    client = get_client()
+    bucket = get_new_bucket(client)
+    key = 'obj'
+
+    size = 0
+    badsize = 9999
+
+    client.put_object(Bucket=bucket, Key=key)
+
+    e = assert_raises(ClientError, client.delete_object, Bucket=bucket, Key=key, IfMatchSize=badsize)
+    assert (412, 'PreconditionFailed') == _get_status_and_error_code(e.response)
+
+    client.delete_object(Bucket=bucket, Key=key, IfMatchSize=size)
+
+    e = assert_raises(ClientError, client.delete_object, Bucket=bucket, Key=key, IfMatchSize=badsize)
+    assert (404, 'NoSuchKey') == _get_status_and_error_code(e.response)
+
+@pytest.mark.fails_on_aws # only supported for directory buckets
+@pytest.mark.conditional_write
+def test_delete_object_current_if_match_size():
+    client = get_client()
+    bucket = get_new_bucket(client)
+    check_configure_versioning_retry(bucket, "Enabled", "Enabled")
+    key = 'obj'
+
+    size = 0
+    badsize = 9999
+
+    client.put_object(Bucket=bucket, Key=key)
+
+    e = assert_raises(ClientError, client.delete_object, Bucket=bucket, Key=key, IfMatchSize=badsize)
+    assert (412, 'PreconditionFailed') == _get_status_and_error_code(e.response)
+
+    response = client.delete_object(Bucket=bucket, Key=key, IfMatchSize=size)
+    assert response['DeleteMarker']
+
+    e = assert_raises(ClientError, client.delete_object, Bucket=bucket, Key=key, IfMatchSize=badsize)
+    assert (404, 'NoSuchKey') == _get_status_and_error_code(e.response)
+
+@pytest.mark.fails_on_aws # only supported for directory buckets
+@pytest.mark.conditional_write
+def test_delete_object_version_if_match_size():
+    client = get_client()
+    bucket = get_new_bucket(client)
+    check_configure_versioning_retry(bucket, "Enabled", "Enabled")
+    key = 'obj'
+
+    size = 0
+    badsize = 9999
+
+    version = client.put_object(Bucket=bucket, Key=key)['VersionId']
+
+    e = assert_raises(ClientError, client.delete_object, Bucket=bucket, Key=key, VersionId=version, IfMatchSize=badsize)
+    assert (412, 'PreconditionFailed') == _get_status_and_error_code(e.response)
+
+    response = client.delete_object(Bucket=bucket, Key=key, VersionId=version, IfMatchSize=size)
+    assert not response['DeleteMarker']
+
+    e = assert_raises(ClientError, client.delete_object, Bucket=bucket, Key=key, VersionId=version, IfMatchSize=badsize)
+    assert (404, 'NoSuchKey') == _get_status_and_error_code(e.response)


### PR DESCRIPTION
test coverage for https://github.com/ceph/ceph/pull/63348
- [x] put_object() with IfMatch and IfNoneMatch
- [x] delete_object() with IfMatch
- [x] delete_object() with IfMatchLastModifiedTime and IfMatchSize
- [x] delete_objects() with `<ETag>`
- [x] delete_objects() with `<LastModifiedTime>`
- [x] delete_objects() with `<Size>`

put_object tests are duplicated to test non-versioned and overwrites of a current version
delete_object(s) tests are duplicated to test non-versioned, deletes of a current version, and deletes of a specific version