### PR TITLE
rgw/cloud-restore: verify if the expiry-date is updated

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -10001,16 +10001,23 @@ def test_restore_object_temporary():
     verify_transition(client, bucket, key, cloud_sc)
 
     # Restore object temporarily
-    client.restore_object(Bucket=bucket, Key=key, RestoreRequest={'Days': 2})
+    client.restore_object(Bucket=bucket, Key=key, RestoreRequest={'Days': 20})
     time.sleep(5)
 
     # Verify object is restored temporarily
     verify_transition(client, bucket, key, cloud_sc)
     response = client.head_object(Bucket=bucket, Key=key)
     assert response['ContentLength'] == len(data)
-    time.sleep(2 * (restore_interval + lc_interval))
 
-    #verify object expired
+    # Now re-issue the request with 'Days' set to lower value
+    client.restore_object(Bucket=bucket, Key=key, RestoreRequest={'Days': 2})
+    time.sleep(2)
+    # ensure the object is still restored
+    response = client.head_object(Bucket=bucket, Key=key)
+    assert response['ContentLength'] == len(data)
+
+    # now verify if the object is expired as per the updated days value
+    time.sleep(2 * (restore_interval + lc_interval))
     response = client.head_object(Bucket=bucket, Key=key)
     assert response['ContentLength'] == 0
 


### PR DESCRIPTION
This is the test-case for https://github.com/ceph/ceph/pull/64804. 

If the `restoe-object` request is re-issued on a cloud-restored object, it should update restoration period accordingly from the time the request is re-issued.