### PR TITLE
s3: tests for wildcard support in conditional read

### DIFF
--- a/s3tests_boto3/functional/test_s3.py
+++ b/s3tests_boto3/functional/test_s3.py
@@ -3101,6 +3101,37 @@ def test_get_object_ifunmodifiedsince_failed():
     body = _get_body(response)
     assert body == 'bar'
 
+def test_get_object_ifmatch_wildcard():
+    bucket_name = get_new_bucket()
+    client = get_client()
+    response = client.put_object(Bucket=bucket_name, Key='foo', Body='bar')
+    response = client.get_object(Bucket=bucket_name, Key='foo', IfMatch='*')
+    body = _get_body(response)
+    assert body == 'bar'
+
+def test_get_object_ifnonematch_wildcard():
+    bucket_name = get_new_bucket()
+    client = get_client()
+    response = client.put_object(Bucket=bucket_name, Key='foo', Body='bar')
+    etag = response['ETag']
+
+    e = assert_raises(ClientError, client.get_object, Bucket=bucket_name, Key='foo', IfNoneMatch='*')
+    status, error_code = _get_status_and_error_code(e.response)
+    assert status == 304
+    assert e.response['Error']['Message'] == 'Not Modified'
+    assert e.response['ResponseMetadata']['HTTPHeaders']['etag'] == etag
+
+def test_get_object_ifmatch_ifnonematch_wildcard():
+    bucket_name = get_new_bucket()
+    client = get_client()
+    response = client.put_object(Bucket=bucket_name, Key='foo', Body='bar')
+    etag = response['ETag']
+
+    e = assert_raises(ClientError, client.get_object, Bucket=bucket_name, Key='foo', IfMatch='*', IfNoneMatch='*')
+    status, error_code = _get_status_and_error_code(e.response)
+    assert status == 304
+    assert e.response['Error']['Message'] == 'Not Modified'
+    assert e.response['ResponseMetadata']['HTTPHeaders']['etag'] == etag
 
 @pytest.mark.fails_on_aws
 def test_put_object_ifmatch_good():


### PR DESCRIPTION
Add test for wildcard '*' support in conditional read.
ceph pr: https://github.com/ceph/ceph/pull/64428

```
fallocate test --len 10MB
aws s3api create-bucket --bucket test
aws s3api put-object --bucket test --key test --body test

# 412 -> 200
aws s3api get-object --bucket test --key test --if-match "*" test-res

# 200 -> 304
aws s3api get-object --bucket test --key test --if-none-match "*" test-res

# 412 -> 304
aws s3api get-object --bucket test --key test --if-none-match "*" --if-match "*" test-res
```
