### PR TITLE
rgw/restore: Add rgw_restore_processor_period config option to determine restore time

### DIFF
--- a/s3tests.conf.SAMPLE
+++ b/s3tests.conf.SAMPLE
@@ -56,6 +56,7 @@ secret_key = h7GhxuBLTrlhVUyxSPUKUV8r/2EI4ngqJxD7iBdBYLhwluN30JaT3Q==
 #lc_debug_interval = 20
 ## Restore debug interval (default: 100)
 #rgw_restore_debug_interval = 60
+#rgw_restore_processor_period = 60
 
 [s3 alt]
 # alt display_name set in vstart.sh

--- a/s3tests_boto3/functional/__init__.py
+++ b/s3tests_boto3/functional/__init__.py
@@ -253,6 +253,11 @@ def configure():
     except (configparser.NoSectionError, configparser.NoOptionError):
         config.rgw_restore_debug_interval = 100
 
+    try:
+        config.rgw_restore_processor_period = int(cfg.get('s3 main',"rgw_restore_processor_period"))
+    except (configparser.NoSectionError, configparser.NoOptionError):
+        config.rgw_restore_processor_period = 100
+
     config.alt_access_key = cfg.get('s3 alt',"access_key")
     config.alt_secret_key = cfg.get('s3 alt',"secret_key")
     config.alt_display_name = cfg.get('s3 alt',"display_name")
@@ -813,6 +818,9 @@ def get_lc_debug_interval():
 
 def get_restore_debug_interval():
     return config.rgw_restore_debug_interval
+
+def get_restore_processor_period():
+    return config.rgw_restore_processor_period
 
 def get_read_through_days():
     return config.read_through_restore_days


### PR DESCRIPTION
With https://github.com/ceph/ceph/pull/64933 , now the restore requests are processed asynchronously even for `cloud-s3` tier types. This change includes option `rgw_restore_processor_period` to determine restore time before verifying in the tests.
