### PR TITLE
s3tests: add tests for per-bucket cloud transition targeting

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -14,6 +14,7 @@ markers =
     checksum
     cloud_transition
     cloud_restore
+    target_by_bucket
     copy
     encryption
     fails_on_aws

--- a/s3tests.conf.SAMPLE
+++ b/s3tests.conf.SAMPLE
@@ -103,6 +103,8 @@ secret_key = nopqrstuvwxyzabcdefghijklmnabcdefghijklm
 # read_through_restore_days = 2
 # target_storage_class = Target_SC
 # target_path = cloud-bucket
+# target_by_bucket = false    # when true, each source bucket gets its own target bucket
+# target_by_bucket_prefix = rgwx-${zonegroup}-${storage_class}-${bucket}  # template for per-bucket target names
 
 ## another regular storage class to test multiple transition rules,
 # storage_class = S1

--- a/s3tests/functional/__init__.py
+++ b/s3tests/functional/__init__.py
@@ -410,6 +410,16 @@ def get_cloud_config(cfg):
     except (configparser.NoSectionError, configparser.NoOptionError):
         config.read_through_restore_days = 10
 
+    try:
+        config.cloud_target_by_bucket = cfg.getboolean('s3 cloud', "target_by_bucket")
+    except (configparser.NoSectionError, configparser.NoOptionError):
+        config.cloud_target_by_bucket = False
+
+    try:
+        config.cloud_target_by_bucket_prefix = cfg.get('s3 cloud', "target_by_bucket_prefix")
+    except (configparser.NoSectionError, configparser.NoOptionError):
+        config.cloud_target_by_bucket_prefix = None
+
 
 def get_client(client_config=None):
     if client_config == None:
@@ -824,6 +834,12 @@ def get_restore_processor_period():
 
 def get_read_through_days():
     return config.read_through_restore_days
+
+def get_cloud_target_by_bucket():
+    return config.cloud_target_by_bucket
+
+def get_cloud_target_by_bucket_prefix():
+    return config.cloud_target_by_bucket_prefix
 
 def create_iam_user_s3client(client):
     prefix = get_iam_path_prefix()


### PR DESCRIPTION
Add tests to validate the target_by_bucket feature which allows each source bucket to transition objects to a dedicated destination bucket rather than sharing a common target.

New tests:
- test_lifecycle_cloud_transition_target_by_bucket: validates objects land in bucket-specific targets and performs a restore from target
- test_lifecycle_cloud_transition_target_by_bucket_multiple_buckets: validates isolation between different source buckets