### PR TITLE
Disable client retries

### DIFF
--- a/s3tests/functional/__init__.py
+++ b/s3tests/functional/__init__.py
@@ -413,7 +413,7 @@ def get_cloud_config(cfg):
 
 def get_client(client_config=None):
     if client_config == None:
-        client_config = Config(signature_version='s3v4')
+        client_config = Config(signature_version='s3v4', retries={'total_max_attempts': 1})
 
     client = boto3.client(service_name='s3',
                         aws_access_key_id=config.main_access_key,


### PR DESCRIPTION
The boto3 client automatically retries failed S3 operations. For negative test cases—where an error is the expected outcome—this leads to unnecessary delays and can obscure real failures by hiding the initial error. To keep tests fast and deterministic, we should disable automatic retries in the S3 client.