### PR TITLE
s3: replace deprecated ssl.wrap_socket()

### DIFF
--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -6800,7 +6800,8 @@ def _simple_http_req_100_cont(host, port, is_secure, method, resource):
 
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     if is_secure:
-        s = ssl.wrap_socket(s);
+        ctx = ssl.create_default_context()
+        s = ctx.wrap_socket(s, server_hostname=host);
     s.settimeout(5)
     s.connect((host, port))
     s.send(req)


### PR DESCRIPTION
this was deprecated in python 3.7 and removed in 3.12

Fixes: https://tracker.ceph.com/issues/75943