### PR TITLE
s3: align conditional write tests with If-None-Match '*' semantics

### DIFF
--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -18895,27 +18895,18 @@ def test_put_object_if_match():
 
     e = assert_raises(ClientError, client.put_object, Bucket=bucket, Key=key, IfNoneMatch='*')
     assert (412, 'PreconditionFailed') == _get_status_and_error_code(e.response)
-    e = assert_raises(ClientError, client.put_object, Bucket=bucket, Key=key, IfNoneMatch=etag)
-    assert (412, 'PreconditionFailed') == _get_status_and_error_code(e.response)
-    response = client.put_object(Bucket=bucket, Key=key, IfNoneMatch='badetag')
-    assert 200 == response['ResponseMetadata']['HTTPStatusCode']
-
-    client.put_object(Bucket=bucket, Key=key, IfMatch=etag)
-
-    client.delete_object(Bucket=bucket, Key=key)
-
-    e = assert_raises(ClientError, client.put_object, Bucket=bucket, Key=key, IfMatch='*')
-    assert (404, 'NoSuchKey') == _get_status_and_error_code(e.response)
-    e = assert_raises(ClientError, client.put_object, Bucket=bucket, Key=key, IfMatch='badetag')
-    assert (404, 'NoSuchKey') == _get_status_and_error_code(e.response)
-
-    response = client.put_object(Bucket=bucket, Key=key, IfNoneMatch=etag)
-    assert 200 == response['ResponseMetadata']['HTTPStatusCode']
-    response = client.put_object(Bucket=bucket, Key=key, IfMatch='*')
-    assert 200 == response['ResponseMetadata']['HTTPStatusCode']
     e = assert_raises(ClientError, client.put_object, Bucket=bucket, Key=key, IfMatch='badetag')
     assert (412, 'PreconditionFailed') == _get_status_and_error_code(e.response)
     response = client.put_object(Bucket=bucket, Key=key, IfMatch=etag)
+    etag = response['ETag']
+    assert 200 == response['ResponseMetadata']['HTTPStatusCode']
+
+    client.delete_object(Bucket=bucket, Key=key)
+
+    e = assert_raises(ClientError, client.put_object, Bucket=bucket, Key=key, IfMatch=etag)
+    assert (404, 'NoSuchKey') == _get_status_and_error_code(e.response)
+
+    response = client.put_object(Bucket=bucket, Key=key, IfNoneMatch='*')
     assert 200 == response['ResponseMetadata']['HTTPStatusCode']
 
 def prepare_multipart_upload(client, bucket, key, body):
@@ -18957,28 +18948,15 @@ def test_multipart_put_object_if_match():
     etag = response['ETag']
 
     failing_conditional_multipart_upload((412, 'PreconditionFailed'), client, bucket, key, IfNoneMatch='*')
-    failing_conditional_multipart_upload((412, 'PreconditionFailed'), client, bucket, key, IfNoneMatch=etag)
-
-    response = successful_conditional_multipart_upload(client, bucket, key, IfNoneMatch='badetag')
-    etag = response['ETag']
-    assert 200 == response['ResponseMetadata']['HTTPStatusCode']
-
+    failing_conditional_multipart_upload((412, 'PreconditionFailed'), client, bucket, key, IfMatch='badetag')
     response = successful_conditional_multipart_upload(client, bucket, key, IfMatch=etag)
     etag = response['ETag']
+    assert 200 == response['ResponseMetadata']['HTTPStatusCode']
 
     client.delete_object(Bucket=bucket, Key=key)
 
-    failing_conditional_multipart_upload((404, 'NoSuchKey'), client, bucket, key, IfMatch='*')
-    failing_conditional_multipart_upload((404, 'NoSuchKey'), client, bucket, key, IfMatch='badetag')
-
-    response = successful_conditional_multipart_upload(client, bucket, key, IfNoneMatch=etag)
-    etag = response['ETag']
-    assert 200 == response['ResponseMetadata']['HTTPStatusCode']
-    response = successful_conditional_multipart_upload(client, bucket, key, IfMatch='*')
-    etag = response['ETag']
-    assert 200 == response['ResponseMetadata']['HTTPStatusCode']
-    failing_conditional_multipart_upload((412, 'PreconditionFailed'), client, bucket, key, IfMatch='badetag')
-    response = successful_conditional_multipart_upload(client, bucket, key, IfMatch=etag)
+    failing_conditional_multipart_upload((404, 'NoSuchKey'), client, bucket, key, IfMatch=etag)
+    response = successful_conditional_multipart_upload(client, bucket, key, IfNoneMatch='*')
     assert 200 == response['ResponseMetadata']['HTTPStatusCode']
 
 @pytest.mark.conditional_write


### PR DESCRIPTION
## Summary

Align the conditional write tests with S3 semantics for `If-None-Match` on write APIs.

## Changes

- keep `If-None-Match` coverage limited to `*` for conditional put and multipart completion
- remove test expectations that treat arbitrary ETags or non-matching values as valid for `If-None-Match`
- keep overwrite/conflict coverage on `If-Match` with concrete ETags instead

## Why

Backends that correctly reject non-`*` `If-None-Match` values were being reported as failures by the test suite. This change narrows the tests to the supported conditional
write behavior and avoids false negatives in compatibility results.
