### PR TITLE
tentacle: rgw/sts: modifying test_assume_role_creds_expiry

### DIFF
--- a/s3tests/functional/test_sts.py
+++ b/s3tests/functional/test_sts.py
@@ -300,7 +300,9 @@ def test_assume_role_creds_expiry():
         s3bucket = s3_client.create_bucket(Bucket=bucket_name)
     except ClientError as e:
         s3bucket_error = e.response.get("Error", {}).get("Code")
-    assert s3bucket_error == 'AccessDenied'
+        http_status_code = e.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+    assert s3bucket_error == 'ExpiredToken'
+    assert http_status_code == 400
 
 @pytest.mark.test_of_sts
 @pytest.mark.fails_on_dbstore


### PR DESCRIPTION
to check for ExpiredToken (400) error code
instead of AccessDenied (403).

backport tracker: https://tracker.ceph.com/issues/76271
parent tracker: https://tracker.ceph.com/issues/76269