### PR TITLE
test/sts: add test for global OIDC provider fallback and precedence

### DIFF
--- a/s3tests/functional/test_sts.py
+++ b/s3tests/functional/test_sts.py
@@ -2166,3 +2166,183 @@ def test_get_caller_identity_after_assume_role():
   assert response['Account'] == account_id
   assert response['Arn'] == assume_role['AssumedRoleUser']['Arn']
 
+@pytest.mark.webidentity_test
+@pytest.mark.fails_on_dbstore
+def test_assume_role_with_global_oidc_provider_local_override():
+    """Test global OIDC provider fallback and account-level precedence.
+
+    Requires a global OIDC provider to be pre-created by the test task
+    (qa/tasks/s3tests.py) via 'radosgw-admin oidc-provider create' with
+    the correct thumbprint and client_ids.
+
+    Phase 1: No account-level provider exists.
+      AssumeRoleWithWebIdentity should SUCCEED via global fallback.
+
+    Phase 2: Create account-level provider with WRONG client_id.
+      AssumeRoleWithWebIdentity should FAIL, proving account-level
+      takes precedence over global (client_id mismatch always validated).
+
+    Phase 3: Delete account-level provider.
+      AssumeRoleWithWebIdentity should SUCCEED again via global fallback.
+    """
+    check_webidentity()
+    iam_client=get_iam_client()
+    sts_client=get_sts_client()
+    default_endpoint=get_config_endpoint()
+    role_session_name=get_parameter_name()
+    thumbprint=get_thumbprint()
+    aud=get_aud()
+    token=get_token()
+    realm=get_realm_name()
+    sub=get_sub()
+
+    idp_url = 'localhost:8080/auth/realms/' + realm
+
+    # Use bare URL as the Federated principal for global OIDC providers
+    policy_document = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Federated\":[\""+idp_url+"\"]},\"Action\":[\"sts:AssumeRoleWithWebIdentity\"],\"Condition\":{\"StringEquals\":{\""+idp_url+":sub\":\""+sub+"\"}}}]}"
+    (role_error,role_response,general_role_name)=create_role(iam_client,'/',None,policy_document,None,None,None)
+    assert role_response['Role']['Arn'] == 'arn:aws:iam:::role/'+general_role_name+''
+
+    role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"s3:*\",\"Resource\":\"arn:aws:s3:::*\"}}"
+    (role_err,response)=put_role_policy(iam_client,general_role_name,None,role_policy)
+    if response:
+        assert response['ResponseMetadata']['HTTPStatusCode'] == 200
+    else:
+        assert False, role_err
+
+    # Phase 1: No account-level provider — should SUCCEED via global fallback
+    resp=sts_client.assume_role_with_web_identity(RoleArn=role_response['Role']['Arn'],RoleSessionName=role_session_name,WebIdentityToken=token)
+    assert resp['ResponseMetadata']['HTTPStatusCode'] == 200
+
+    # Verify temp credentials work for S3 operations
+    s3_client = boto3.client('s3',
+		aws_access_key_id = resp['Credentials']['AccessKeyId'],
+		aws_secret_access_key = resp['Credentials']['SecretAccessKey'],
+		aws_session_token = resp['Credentials']['SessionToken'],
+		endpoint_url=default_endpoint,
+		region_name='',
+		)
+    bucket_name = get_new_bucket_name()
+    s3bucket = s3_client.create_bucket(Bucket=bucket_name)
+    assert s3bucket['ResponseMetadata']['HTTPStatusCode'] == 200
+    bkt = s3_client.delete_bucket(Bucket=bucket_name)
+    assert bkt['ResponseMetadata']['HTTPStatusCode'] == 204
+
+    # Phase 2: Create account-level provider with WRONG client_id (same URL as global)
+    # client_id is always validated against the JWT's aud/azp claim regardless of TLS
+    oidc_response = iam_client.create_open_id_connect_provider(
+    Url='http://localhost:8080/auth/realms/{}'.format(realm),
+    ThumbprintList=[
+        thumbprint,
+    ],
+    ClientIDList=[
+        'wrong_client_id',
+    ],
+    )
+
+    # Should FAIL — account-level has wrong client_id, proving it takes precedence over global
+    token=get_token()
+    try:
+        resp=sts_client.assume_role_with_web_identity(RoleArn=role_response['Role']['Arn'],RoleSessionName=role_session_name,WebIdentityToken=token)
+        assert False, "Expected failure due to wrong client_id in account-level provider"
+    except ClientError as e:
+        assert e.response['Error']['Code'] in ('AccessDenied', 'InvalidIdentityToken')
+
+    # Phase 3: Delete account-level provider, fallback should resume
+    iam_client.delete_open_id_connect_provider(
+    OpenIDConnectProviderArn=oidc_response["OpenIDConnectProviderArn"]
+    )
+
+    token=get_token()
+    resp=sts_client.assume_role_with_web_identity(RoleArn=role_response['Role']['Arn'],RoleSessionName=role_session_name,WebIdentityToken=token)
+    assert resp['ResponseMetadata']['HTTPStatusCode'] == 200
+
+@pytest.mark.webidentity_test
+@pytest.mark.fails_on_dbstore
+def test_assume_role_with_global_oidc_trust_policy_scope():
+    """Test trust policy principal matching with global and account-scoped providers.
+
+    Requires a global OIDC provider to be pre-created by the test task.
+
+    Case 1: Bare URL in trust policy + global provider → SUCCEED
+    Case 2: Mismatched tenant ARN in trust policy + global provider → FAIL
+    Case 3: Account-scoped ARN in trust policy + account provider → SUCCEED
+    Case 4: Bare URL in trust policy + account provider → FAIL
+      (bare URL sets account=".global", which doesn't match account-scoped provider)
+    """
+    check_webidentity()
+    iam_client=get_iam_client()
+    sts_client=get_sts_client()
+    default_endpoint=get_config_endpoint()
+    role_session_name=get_parameter_name()
+    thumbprint=get_thumbprint()
+    aud=get_aud()
+    token=get_token()
+    realm=get_realm_name()
+    sub=get_sub()
+
+    idp_url = 'localhost:8080/auth/realms/' + realm
+    oidc_arn = 'arn:aws:iam:::oidc-provider/' + idp_url
+
+    role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"s3:*\",\"Resource\":\"arn:aws:s3:::*\"}}"
+
+    # Case 1: Bare URL in trust policy + global provider → SUCCEED
+    policy_bare_url = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Federated\":[\""+idp_url+"\"]},\"Action\":[\"sts:AssumeRoleWithWebIdentity\"],\"Condition\":{\"StringEquals\":{\""+idp_url+":sub\":\""+sub+"\"}}}]}"
+    (role_error,role_response_1,role_name_1)=create_role(iam_client,'/',None,policy_bare_url,None,None,None)
+    assert role_response_1['Role']['Arn'] == 'arn:aws:iam:::role/'+role_name_1
+
+    (role_err,response)=put_role_policy(iam_client,role_name_1,None,role_policy)
+    assert response['ResponseMetadata']['HTTPStatusCode'] == 200
+
+    resp=sts_client.assume_role_with_web_identity(RoleArn=role_response_1['Role']['Arn'],RoleSessionName=role_session_name,WebIdentityToken=token)
+    assert resp['ResponseMetadata']['HTTPStatusCode'] == 200
+
+    # Case 2: Mismatched tenant ARN in trust policy + global provider → FAIL
+    wrong_arn = 'arn:aws:iam::wrongTenant:oidc-provider/' + idp_url
+    policy_wrong_tenant = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Federated\":[\""+wrong_arn+"\"]},\"Action\":[\"sts:AssumeRoleWithWebIdentity\"],\"Condition\":{\"StringEquals\":{\""+idp_url+":sub\":\""+sub+"\"}}}]}"
+    (role_error,role_response_2,role_name_2)=create_role(iam_client,'/',None,policy_wrong_tenant,None,None,None)
+    assert role_response_2['Role']['Arn'] == 'arn:aws:iam:::role/'+role_name_2
+
+    (role_err,response)=put_role_policy(iam_client,role_name_2,None,role_policy)
+    assert response['ResponseMetadata']['HTTPStatusCode'] == 200
+
+    token=get_token()
+    try:
+        resp=sts_client.assume_role_with_web_identity(RoleArn=role_response_2['Role']['Arn'],RoleSessionName=role_session_name,WebIdentityToken=token)
+        assert False, "Expected failure: mismatched tenant ARN in trust policy with global provider"
+    except ClientError as e:
+        assert e.response['Error']['Code'] in ('AccessDenied', 'InvalidIdentityToken')
+
+    # Case 3: Create account-level provider, ARN trust policy → SUCCEED
+    oidc_response = iam_client.create_open_id_connect_provider(
+        Url='http://localhost:8080/auth/realms/{}'.format(realm),
+        ThumbprintList=[thumbprint],
+        ClientIDList=[aud],
+    )
+
+    policy_scoped_arn = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Federated\":[\""+oidc_arn+"\"]},\"Action\":[\"sts:AssumeRoleWithWebIdentity\"],\"Condition\":{\"StringEquals\":{\""+idp_url+":sub\":\""+sub+"\"}}}]}"
+    (role_error,role_response_3,role_name_3)=create_role(iam_client,'/',None,policy_scoped_arn,None,None,None)
+    assert role_response_3['Role']['Arn'] == 'arn:aws:iam:::role/'+role_name_3
+
+    (role_err,response)=put_role_policy(iam_client,role_name_3,None,role_policy)
+    assert response['ResponseMetadata']['HTTPStatusCode'] == 200
+
+    token=get_token()
+    resp=sts_client.assume_role_with_web_identity(RoleArn=role_response_3['Role']['Arn'],RoleSessionName=role_session_name,WebIdentityToken=token)
+    assert resp['ResponseMetadata']['HTTPStatusCode'] == 200
+
+    # Case 4: Bare URL trust policy + account provider → FAIL
+    # Bare URL sets account=".global" in the principal, which won't match
+    # the account-scoped provider (is_global_oidc=false, role_tenant="")
+    token=get_token()
+    try:
+        resp=sts_client.assume_role_with_web_identity(RoleArn=role_response_1['Role']['Arn'],RoleSessionName=role_session_name,WebIdentityToken=token)
+        assert False, "Expected failure: bare URL in trust policy with account-scoped provider"
+    except ClientError as e:
+        assert e.response['Error']['Code'] in ('AccessDenied', 'InvalidIdentityToken')
+
+    # Cleanup
+    iam_client.delete_open_id_connect_provider(
+        OpenIDConnectProviderArn=oidc_response["OpenIDConnectProviderArn"]
+    )
+


### PR DESCRIPTION
Add test_assume_role_with_global_oidc_provider_local_override() which validates three scenarios:
1. AssumeRoleWithWebIdentity succeeds via global OIDC provider when no account-level provider exists (fallback path)
2. Account-level provider with wrong client_id causes failure, proving account-level takes precedence over global (client_id validation is always enforced regardless of TLS)
3. After deleting account-level provider, fallback to global resumes

Requires the test task (qa/tasks/s3tests.py) to pre-create a global OIDC provider via 'radosgw-admin oidc-provider create' (done by qa/tasks/s3tests.py in the companion ceph PR #[68850](https://github.com/ceph/ceph/pull/68850)) 

Verified locally with Keycloak 11.0.