### PR TITLE
test_s3: fix test_bucket_logging_request_id for newer botocore

### DIFF
--- a/s3tests/functional/test_s3.py
+++ b/s3tests/functional/test_s3.py
@@ -15748,14 +15748,9 @@ def test_bucket_logging_request_id():
     assert response['ResponseMetadata']['HTTPStatusCode'] == 200
 
     # capture x-amz-request-id from the put_object response
-    request_id = None
-    def capture_request_id(**kwargs):
-        nonlocal request_id
-        request_id = kwargs['response']['ResponseMetadata']['HTTPHeaders'].get('x-amz-request-id')
-    client.meta.events.register('after-call.s3.PutObject', capture_request_id)
-
-    client.put_object(Bucket=src_bucket_name, Key=key, Body=randcontent())
-    assert request_id is not None, 'failed to capture x-amz-request-id from response'
+    response = client.put_object(Bucket=src_bucket_name, Key=key, Body=randcontent())
+    request_id = response['ResponseMetadata']['HTTPHeaders'].get('x-amz-request-id')
+    assert request_id is not None, 'failed to read x-amz-request-id from response headers'
 
     _flush_logs(client, src_bucket_name)
     response = client.list_objects_v2(Bucket=log_bucket_name)


### PR DESCRIPTION
The test `test_bucket_logging_request_id` (introduced in #729) registers
a boto3 `after-call.s3.PutObject` event handler that incorrectly accesses
`kwargs["response"]`.  Botocore does not pass a `response` kwarg in
`after-call` events; the correct kwargs are `parsed`, `http_response`,
`model`, and `context`.

This causes the test to fail in teuthology with:

    KeyError: "response"
    s3tests/functional/test_s3.py:15754: KeyError

Fix by reading the `x-amz-request-id` header directly from the
`put_object()` response, which is simpler and works across all botocore
versions.

Fixes: http://tracker.ceph.com/issues/76587
Related: https://github.com/ceph/s3-tests/pull/729